### PR TITLE
rusqlite: Apply entire migration

### DIFF
--- a/refinery_migrations/src/drivers/rusqlite.rs
+++ b/refinery_migrations/src/drivers/rusqlite.rs
@@ -32,7 +32,8 @@ impl Transaction for RqlConnection {
         let transaction = self.transaction()?;
         let mut count = 0;
         for query in queries.iter() {
-            count += transaction.execute(query, NO_PARAMS)?;
+            transaction.execute_batch(query)?;
+            count += 1;
         }
         transaction.commit()?;
         Ok(count)


### PR DESCRIPTION
`Connection::execute` only executes one query, `Connection::execute_batch` executes all. There should probably be a test for the completeness of a single migration.