### PR TITLE
update postgres and tokio-postgres to stable versions 0.17.0 and 0.5.0 respectively

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
       - checkout
       - run: rustup self update
       - run: cd refinery_macros && cargo test
-      - run: cd refinery_migrations && cargo test --features=sync,postgres
+      - run: cd refinery_migrations && cargo test --features=sync,mysql
       - run: cd refinery_cli && cargo test
   cargo-fmt-clippy-and-test-macros-and-cli-stable:
     docker:
@@ -70,21 +70,21 @@ jobs:
       - image: << pipeline.parameters.previous >>
     steps:
       - checkout
-      - run: cargo build -p refinery_cli
+      - run: cargo install --path ./refinery_cli --no-default-features --features=sqlite-bundled
       - run: cd refinery && cargo test --features "trusqlite" --test rusqlite
   test-sqlite-stable:
     docker:
       - image: << pipeline.parameters.stable >>
     steps:
       - checkout
-      - run: cargo build -p refinery_cli
+      - run: cargo install --path ./refinery_cli --no-default-features --features=sqlite-bundled
       - run: cd refinery && cargo test --features "trusqlite" --test rusqlite
   test-sqlite-nightly:
     docker:
       - image: << pipeline.parameters.nightly >>
     steps:
       - checkout
-      - run: cargo build -p refinery_cli
+      - run: cargo install --path ./refinery_cli --no-default-features --features=sqlite-bundled
       - run: cd refinery && cargo test --features "trusqlite" --test rusqlite
   test-postgres-previous:
     docker:
@@ -92,7 +92,7 @@ jobs:
       - image: postgres:9.6.13-alpine
     steps:
       - checkout
-      - run: cargo build -p refinery_cli
+      - run: cargo install --path ./refinery_cli --no-default-features --features=postgres
       - run: cd refinery && cargo test -p refinery --features "tpostgres" --test postgres -- --test-threads 1
   test-postgres-stable:
     docker:
@@ -100,7 +100,7 @@ jobs:
       - image: postgres:9.6.13-alpine
     steps:
       - checkout
-      - run: cargo build -p refinery_cli
+      - run: cargo install --path ./refinery_cli --no-default-features --features=postgres
       - run: cd refinery && cargo test -p refinery --features "tpostgres" --test postgres -- --test-threads 1
   test-postgres-nightly:
     docker:
@@ -108,7 +108,7 @@ jobs:
       - image: postgres:9.6.13-alpine
     steps:
       - checkout
-      - run: cargo build -p refinery_cli
+      - run: cargo install --path ./refinery_cli --no-default-features --features=postgres
       - run: cd refinery && cargo test -p refinery --features "tpostgres" --test postgres -- --test-threads 1
   test-tokio-postgres-stable:
     docker:
@@ -116,7 +116,6 @@ jobs:
       - image: postgres:9.6.13-alpine
     steps:
       - checkout
-      - run: cargo build -p refinery_cli
       - run: cd refinery && cargo test -p refinery --features "tttokio-postgres" --test tokio_postgres -- --test-threads 1
   test-tokio-postgres-nightly:
     docker:
@@ -124,7 +123,6 @@ jobs:
       - image: postgres:9.6.13-alpine
     steps:
       - checkout
-      - run: cargo build -p refinery_cli
       - run: cd refinery && cargo test -p refinery --features "tttokio-postgres" --test tokio_postgres -- --test-threads 1
   test-mysql-previous:
     docker:
@@ -137,7 +135,7 @@ jobs:
           MYSQL_DATABASE: refinery_test
     steps:
       - checkout
-      - run: cargo build -p refinery_cli
+      - run: cargo install --path ./refinery_cli --no-default-features --features=mysql
       - run: cd refinery && cargo test -p refinery --features "tmysql" --test mysql -- --test-threads 1
   test-mysql-stable:
     docker:
@@ -150,7 +148,7 @@ jobs:
           MYSQL_DATABASE: refinery_test
     steps:
       - checkout
-      - run: cargo build -p refinery_cli
+      - run: cargo install --path ./refinery_cli --no-default-features --features=mysql
       - run: cd refinery && cargo test -p refinery --features "tmysql" --test mysql -- --test-threads 1
   test-mysql-nightly:
     docker:
@@ -163,7 +161,7 @@ jobs:
           MYSQL_DATABASE: refinery_test
     steps:
       - checkout
-      - run: cargo build -p refinery_cli
+      - run: cargo install --path ./refinery_cli --no-default-features --features=mysql
       - run: cd refinery && cargo test -p refinery --features "tmysql" --test mysql -- --test-threads 1
   test-mysql-async-stable:
     docker:
@@ -176,7 +174,6 @@ jobs:
           MYSQL_DATABASE: refinery_test
     steps:
       - checkout
-      - run: cargo build -p refinery_cli
       - run: cd refinery && cargo test -p refinery --features ttmysql_async --test mysql_async -- --test-threads 1
   test-mysql-async-nightly:
     docker:
@@ -189,7 +186,6 @@ jobs:
           MYSQL_DATABASE: refinery_test
     steps:
       - checkout
-      - run: cargo build -p refinery_cli
       - run: cd refinery && cargo test -p refinery --features ttmysql_async --test mysql_async -- --test-threads 1
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
       - run: rustup self update
       - run: cd refinery_macros && cargo test
       - run: cd refinery_migrations && cargo test --features=sync,mysql
-      - run: cd refinery_cli && cargo test
+      - run: cd refinery_cli && cargo test --features=mysql,postgres-previous,sqlite-bundled --no-default-features
   cargo-fmt-clippy-and-test-macros-and-cli-stable:
     docker:
       - image: << pipeline.parameters.stable >>
@@ -92,8 +92,8 @@ jobs:
       - image: postgres:9.6.13-alpine
     steps:
       - checkout
-      - run: cargo install --path ./refinery_cli --no-default-features --features=postgres
-      - run: cd refinery && cargo test -p refinery --features "tpostgres" --test postgres -- --test-threads 1
+      - run: cargo install --path ./refinery_cli --no-default-features --features=postgres-previous
+      - run: cd refinery && cargo test -p refinery --features "tppostgres" --test postgres_previous -- --test-threads 1
   test-postgres-stable:
     docker:
       - image: << pipeline.parameters.stable >>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,12 @@
   - Add `mysql_async` driver suport [#22](https://github.com/rust-db/refinery/pull/19).
   - Add `migrate_from_config` function
   - Add `migrate_from_config_async` function
+  - Update postgres to version 0.17 [#32](https://github.com/rust-db/refinery/pull/32)
+  - Allow refinery_cli to select driver via features [#32](https://github.com/rust-db/refinery/pull/32)
 
 - **Bugfixes**:
   - allow multiple statements in migration files [#10](https://github.com/rust-db/refinery/issues/21)
+  - when building refinery_cli with default features, build with rusqlite bundled libsqlite3 [#33](https://github.com/rust-db/refinery/issues/21)
 
 - **Dependencies**:
   - update rusqlite dependency, 0.18 -> 0.21 [#26](https://github.com/rust-db/refinery/issues/26)

--- a/README.md
+++ b/README.md
@@ -55,8 +55,7 @@ refinery's design is based on [flyway](https://flywaydb.org/) and so, shares its
 
 ## Compatibility
 
-refinery aims to support stable Rust, the previous Rust version, and nightly.
-
+refinery aims to support stable Rust, the previous Rust version, and nightly. To build Refinery with Rust 1.39 you have to select feature `postgres-previous` instead of `postgres` so that refinery builds with `postgres` version `0.15` instead of version `0.17`
 
 ## Async
 

--- a/refinery/Cargo.toml
+++ b/refinery/Cargo.toml
@@ -15,6 +15,7 @@ edition = "2018"
 default = []
 rusqlite = ["refinery-migrations/sync", "refinery-migrations/rusqlite", "barrel/sqlite3"]
 postgres = ["refinery-migrations/sync", "refinery-migrations/postgres", "barrel/pg"]
+postgres-previous = ["refinery-migrations/sync", "refinery-migrations/postgres-previous", "barrel/pg"]
 mysql = ["refinery-migrations/sync", "refinery-migrations/mysql", "barrel/mysql"]
 tokio-postgres = ["refinery-migrations/async", "refinery-migrations/tokio-postgres", "refinery-migrations/tokio", "barrel/pg"]
 mysql_async = ["refinery-migrations/async", "refinery-migrations/mysql_async", "barrel/pg"]
@@ -22,6 +23,7 @@ mysql_async = ["refinery-migrations/async", "refinery-migrations/mysql_async", "
 #testing features
 trusqlite = ["rusqlite", "mod_migrations/sqlite"]
 tpostgres = ["ttpostgres", "postgres", "mod_migrations/pg"]
+tppostgres = ["tpppostgres", "postgres-previous", "mod_migrations/pg"]
 tmysql = ["mysql", "mod_migrations/mysql"]
 tttokio-postgres = ["tokio", "ttokio-postgres", "tokio-postgres", "mod_migrations/pg"]
 ttmysql_async = ["tokio", "mysql_async", "tmysql_async", "mod_migrations/mysql"]
@@ -35,7 +37,8 @@ barrel = "0.5.3"
 tokio = { version = "0.2", features = ["full"], optional = true }
 ttokio-postgres = {package = "tokio-postgres", version = "0.5.0", optional = true }
 tmysql_async = { package = "mysql_async", version = "0.21", optional = true }
-ttpostgres = {package = "postgres", version = "0.15", optional = true }
+ttpostgres = {package = "postgres", version = "0.17", optional = true }
+tpppostgres = {package = "postgres", version = "0.15", optional = true }
 
 [dev-dependencies]
 ttrusqlite = {package = "rusqlite", version = "0.21"}

--- a/refinery/Cargo.toml
+++ b/refinery/Cargo.toml
@@ -21,24 +21,24 @@ mysql_async = ["refinery-migrations/async", "refinery-migrations/mysql_async", "
 
 #testing features
 trusqlite = ["rusqlite", "mod_migrations/sqlite"]
-tpostgres = ["postgres", "mod_migrations/pg"]
+tpostgres = ["ttpostgres", "postgres", "mod_migrations/pg"]
 tmysql = ["mysql", "mod_migrations/mysql"]
 tttokio-postgres = ["tokio", "ttokio-postgres", "tokio-postgres", "mod_migrations/pg"]
 ttmysql_async = ["tokio", "mysql_async", "tmysql_async", "mod_migrations/mysql"]
 
 [dependencies]
-refinery-migrations = { version = "0.2.0-alpha.1", path = "../refinery_migrations" }
-refinery-macros= { version = "0.2.0-alpha.1", path = "../refinery_macros" }
+refinery-migrations = { version = "0.2.0-alpha.2", path = "../refinery_migrations" }
+refinery-macros= { version = "0.2.0-alpha.2", path = "../refinery_macros" }
 barrel = "0.5.3"
 # hack because there's no optional dev-dependencies
-# and rust 1.38 doesn't support async fn's, TODO: remove when previous version is 1.38
+# and rust 1.39 doesn't support #[non_exhaustive], TODO: remove when previous version is 1.40
 tokio = { version = "0.2", features = ["full"], optional = true }
-ttokio-postgres = {package = "tokio-postgres", version = "0.5.0-alpha.2", optional = true }
+ttokio-postgres = {package = "tokio-postgres", version = "0.5.0", optional = true }
 tmysql_async = { package = "mysql_async", version = "0.21", optional = true }
+ttpostgres = {package = "postgres", version = "0.15", optional = true }
 
 [dev-dependencies]
 ttrusqlite = {package = "rusqlite", version = "0.21"}
-ttpostgres = {package = "postgres", version = "0.15"}
 futures = "0.3.1"
 ttmysql = {package = "mysql", version = "16.0"}
 

--- a/refinery/README.md
+++ b/refinery/README.md
@@ -55,12 +55,11 @@ refinery's design is based on [flyway](https://flywaydb.org/) and so, shares its
 
 ## Compatibility
 
-refinery aims to support stable Rust, the previous Rust version, and nightly.
-
+refinery aims to support stable Rust, the previous Rust version, and nightly. To build Refinery with Rust 1.39 you have to select feature `postgres-previous` instead of `postgres` so that refinery builds with `postgres` version `0.15` instead of version `0.17`
 
 ## Async
 
-Refinery supports [tokio-postgres](https://crates.io/crates/tokio-postgres) and [`mysql_async`](https://crates.io/crates/mysql_async). To migrate async you have to call `Runner`'s [run_async](https://github.com/rust-db/refinery/blob/master/refinery_migrations/src/lib.rs#L216).
+Starting with version 0.2 refinery supports [tokio-postgres](https://crates.io/crates/tokio-postgres) and [`mysql_async`](https://crates.io/crates/mysql_async). To migrate async you have to call `Runner`'s [run_async](https://github.com/rust-db/refinery/blob/master/refinery_migrations/src/lib.rs#L216).
 There are plans to support [Tiberius](https://github.com/steffengy/tiberius) when futures 0.3 support stabilizes.
 For Rusqlite, the best way to run migrations in an async context is to run them inside tokio's [`block_in_place`](https://docs.rs/tokio/0.2.0/tokio/task/fn.block_in_place.html) for example.
 

--- a/refinery/src/lib.rs
+++ b/refinery/src/lib.rs
@@ -40,5 +40,10 @@ pub use refinery_migrations::{Config, ConfigDbType};
 #[cfg(any(feature = "mysql_async", feature = "tokio-postgres"))]
 pub use refinery_migrations::{migrate_from_config_async, AsyncMigrate};
 
-#[cfg(any(feature = "mysql", feature = "postgres", feature = "rusqlite"))]
+#[cfg(any(
+    feature = "mysql",
+    feature = "postgres",
+    feature = "postgres-previous",
+    feature = "rusqlite"
+))]
 pub use refinery_migrations::{migrate_from_config, Migrate};

--- a/refinery/tests/mysql.rs
+++ b/refinery/tests/mysql.rs
@@ -465,8 +465,7 @@ mod mysql {
     #[test]
     fn migrates_from_cli() {
         run_test(|| {
-            Command::cargo_bin("refinery")
-                .unwrap()
+            Command::new("refinery")
                 .args(&[
                     "migrate",
                     "-c",
@@ -475,6 +474,7 @@ mod mysql {
                     "-p",
                     "tests/sql_migrations",
                 ])
+                .unwrap()
                 .assert()
                 .stdout(contains("applying migration: V3__add_brand_to_cars_table"));
         })

--- a/refinery/tests/postgres.rs
+++ b/refinery/tests/postgres.rs
@@ -502,8 +502,7 @@ mod postgres {
     #[test]
     fn migrates_from_cli() {
         run_test(|| {
-            Command::cargo_bin("refinery")
-                .unwrap()
+            Command::new("refinery")
                 .args(&[
                     "migrate",
                     "-c",
@@ -512,6 +511,7 @@ mod postgres {
                     "-p",
                     "tests/sql_migrations",
                 ])
+                .unwrap()
                 .assert()
                 .stdout(contains("applying migration: V3__add_brand_to_cars_table"));
         })

--- a/refinery/tests/rusqlite.rs
+++ b/refinery/tests/rusqlite.rs
@@ -414,8 +414,7 @@ mod rusqlite {
     #[test]
     fn migrates_from_cli() {
         run_test(|| {
-            Command::cargo_bin("refinery")
-                .unwrap()
+            Command::new("refinery")
                 .args(&[
                     "migrate",
                     "-c",
@@ -424,6 +423,7 @@ mod rusqlite {
                     "-p",
                     "tests/sql_migrations",
                 ])
+                .unwrap()
                 .assert()
                 .stdout(contains("applying migration: V3__add_brand_to_cars_table"));
         })

--- a/refinery_cli/Cargo.toml
+++ b/refinery_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "refinery_cli"
-version = "0.2.0-alpha.1"
+version = "0.2.0-alpha.2"
 authors = ["Katharina Fey <kookie@spacekookie.de>", "João Oliveira <hello@jxs.pt>"]
 license = "MIT OR Apache-2.0"
 description = "Provides the CLI for the Refinery crate"
@@ -14,12 +14,20 @@ edition = "2018"
 name = "refinery"
 path = "src/main.rs"
 
+[features]
+default = ["refinery-migrations/sync", "refinery-migrations/mysql", "refinery-migrations/postgres", "refinery-migrations/rusqlite-bundled"]
+postgres = ["refinery-migrations/sync", "refinery-migrations/postgres"]
+mysql = ["refinery-migrations/sync", "refinery-migrations/mysql"]
+sqlite = ["refinery-migrations/sync", "refinery-migrations/rusqlite"]
+sqlite-bundled = ["refinery-migrations/sync", "refinery-migrations/rusqlite-bundled"]
+
+
 [dependencies]
 chrono = "0.4"
 clap = { version = "^2.33", features = ["wrap_help"] }
 exitfailure = "0.5.1"
 human-panic = "1.0.1"
-refinery-migrations = {version = "0.2.0-alpha.1", features = ["sync", "mysql", "postgres", "rusqlite"], path = "../refinery_migrations" }
+refinery-migrations = {version = "0.2.0-alpha.2", path = "../refinery_migrations", optional = true }
 toml = "0.5.1"
 env_logger = "0.6.1"
 log = "0.4.6"

--- a/refinery_cli/Cargo.toml
+++ b/refinery_cli/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/main.rs"
 [features]
 default = ["refinery-migrations/sync", "refinery-migrations/mysql", "refinery-migrations/postgres", "refinery-migrations/rusqlite-bundled"]
 postgres = ["refinery-migrations/sync", "refinery-migrations/postgres"]
+postgres-previous = ["refinery-migrations/sync", "refinery-migrations/postgres-previous"]
 mysql = ["refinery-migrations/sync", "refinery-migrations/mysql"]
 sqlite = ["refinery-migrations/sync", "refinery-migrations/rusqlite"]
 sqlite-bundled = ["refinery-migrations/sync", "refinery-migrations/rusqlite-bundled"]

--- a/refinery_macros/Cargo.toml
+++ b/refinery_macros/Cargo.toml
@@ -18,7 +18,7 @@ proc-macro2 = "0.4.29"
 lazy_static = "1.3.0"
 log = "0.4.6"
 barrel = "0.5.7"
-refinery-migrations= { version = "0.2.0-alpha.1", path = "../refinery_migrations" }
+refinery-migrations= { version = "0.2.0-alpha.2", path = "../refinery_migrations" }
 
 [dev-dependencies]
 barrel = {version = "0.5.7", features = ["mysql"]}

--- a/refinery_migrations/Cargo.toml
+++ b/refinery_migrations/Cargo.toml
@@ -18,7 +18,8 @@ lazy_static = "1.3"
 regex = "1.1"
 log = "0.4"
 rusqlite = {version = "0.21", optional = true}
-postgres = {version = "0.15", optional = true}
+postgres = {version = "0.17", optional = true}
+postgres-previous = { package = "postgres", version = "0.15", optional = true}
 mysql = {version = "16.0", optional = true}
 chrono = "0.4"
 walkdir = "2.2"

--- a/refinery_migrations/Cargo.toml
+++ b/refinery_migrations/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 [features]
 sync = []
 async = []
+rusqlite-bundled = ["rusqlite", "rusqlite/bundled"]
 
 [dependencies]
 lazy_static = "1.3"
@@ -25,7 +26,7 @@ serde = { version = "1.0", features = ["derive"] }
 cfg-if = "0.1"
 thiserror = "1.0"
 async-trait = "0.1"
-tokio-postgres = { version = "0.5.0-alpha.2", optional = true }
+tokio-postgres = { version = "0.5.0", optional = true }
 toml = "0.5.5"
 mysql_async = { version = "0.21.1", optional = true }
 tokio = { version = "0.2", features = ["full"], optional = true }

--- a/refinery_migrations/src/drivers/mod.rs
+++ b/refinery_migrations/src/drivers/mod.rs
@@ -10,5 +10,8 @@ pub mod mysql_async;
 #[cfg(feature = "postgres")]
 pub mod postgres;
 
+#[cfg(feature = "postgres-previous")]
+pub mod postgres_previous;
+
 #[cfg(feature = "mysql")]
 pub mod mysql;


### PR DESCRIPTION
allow refinery-cli to select drivers via features