### PR TITLE
Add docs.rs metadata, fix broken links

### DIFF
--- a/refinery/Cargo.toml
+++ b/refinery/Cargo.toml
@@ -51,6 +51,5 @@ assert_cmd = "0.11.1"
 predicates = "1.0.1"
 tempfile = "3.1.0"
 
-# [package.metadata.docs.rs]
-# features = ["postgres", "mysql", "sqlite", "extras"]
-# no-default-features = true
+[package.metadata.docs.rs]
+all-features = true

--- a/refinery/src/lib.rs
+++ b/refinery/src/lib.rs
@@ -8,9 +8,12 @@ currently [`Postgres`](https://crates.io/crates/postgres), [`Rusqlite`](https://
 
 ## Usage
 
-- Migrations can be defined in .sql files or Rust modules that must have a function called `migration` that returns a [`String`](https://doc.rust-lang.org/std/string/struct.String.html)
+- Migrations can be defined in .sql files or Rust modules that must have a function called `migration` that returns a [`String`](std::string::String)
 - Migrations, both .sql files and Rust modules must be named in the format `V{1}__{2}.rs ` where `{1}` represents the migration version and `{2}` the name.
-- Migrations can be run either by embedding them on your Rust code with [`embedded_migrations`](../refinery_macros/macro.embed_migrations.html) and [`include_migration_mods`](../refinery_macros/macro.include_migration_mods.html) macros, or via `refinery_cli`.
+- Migrations can be run either by embedding them on your Rust code with [`embedded_migrations!`] and [`include_migration_mods!`] macros, or via `refinery_cli`.
+
+[`embedded_migrations!`]: macro.embed_migrations.html
+[`include_migration_mods!`]: macro.include_migration_mods.html
 
 ### Example
 ```rust,no_run

--- a/refinery_macros/src/lib.rs
+++ b/refinery_macros/src/lib.rs
@@ -28,7 +28,7 @@ fn migration_fn_quoted<T: ToTokens>(_migrations: Vec<T>) -> TokenStream2 {
     result
 }
 
-/// imports rust migration modules with migrations and inserts a function called runner that when called returns a [Runner](../refinery/struct.Runner.html) instance with the collected migration modules.
+/// imports rust migration modules with migrations and inserts a function called runner that when called returns a [Runner](refinery_migrations::Runner) instance with the collected migration modules.
 ///
 /// `include_migration_mods` expects to be called from a `mod.rs` file in directory called migrations below the src directory of your Rust project.
 /// if you want the directory to have another name you have to call `include_migration_mods` with it's path relative to the crate root.
@@ -87,10 +87,10 @@ pub fn include_migration_mods(input: TokenStream) -> TokenStream {
     result.into()
 }
 
-/// embeds sql migration files and inserts a function called runner that when called returns a [Runner](../refinery/struct.Runner.html) instance with the collected migration files
+/// embeds sql migration files and inserts a function called runner that when called returns a [Runner](refinery_migrations::Runner) instance with the collected migration files
 ///
 /// when called without arguments `embed_migrations` searches for migration files on a directory called `migrations` at the root level of your crate.
-/// if you want to specify anothe directory call `embed_migrations!` with it's location relative to the root level of your crate.
+/// if you want to specify another directory call `embed_migrations!` with it's location relative to the root level of your crate.
 ///
 /// To be a valid migration module, it has to be named in the format `V{1}__{2}.sql ` where `{1}` represents the migration version and `{2}` the name.
 /// For the name alphanumeric characters plus "_"  are supported.

--- a/refinery_migrations/src/lib.rs
+++ b/refinery_migrations/src/lib.rs
@@ -34,8 +34,11 @@ pub enum MigrationPrefix {
 }
 
 /// Represents a schema migration to be run on the database,
-/// this struct is used by the [embed_migrations](../refinery_macros/macro.embed_migrations.html) and the [mod_migrations](../refinery_macros/macro.mod_migrations.html) to gather migration files
+/// this struct is used by the [`embed_migrations!`] and [`mod_migrations!`] macros to gather migration files
 /// and shouldn't be needed by the user
+///
+/// [`embed_migrations!`]: https://docs.rs/refinery/~0/refinery/macro.embed_migrations.html
+/// [`mod_migrations!`]: https://docs.rs/refinery/~0/refinery/macro.mod_migrations.html
 #[derive(Clone, Debug)]
 pub struct Migration {
     pub name: String,
@@ -134,9 +137,12 @@ impl fmt::Display for AppliedMigration {
     }
 }
 
-///Struct that represents the entrypoint to run the migrations,
-///an instance of this struct is returned by the [embed_migrations](../refinery_macros/macro.embed_migrations.html) and the [mod_migrations](../refinery_macros/macro.mod_migrations.html)
-/// runner function, Runner should not need to be instantiated manually
+/// Struct that represents the entrypoint to run the migrations,
+/// an instance of this struct is returned by the [`embed_migrations!`] and [`mod_migrations!`] macros.
+/// `Runner` should not need to be instantiated manually
+///
+/// [`embed_migrations!`]: https://docs.rs/refinery/~0/refinery/macro.embed_migrations.html
+/// [`mod_migrations!`]: https://docs.rs/refinery/~0/refinery/macro.mod_migrations.html
 pub struct Runner {
     grouped: bool,
     abort_divergent: bool,


### PR DESCRIPTION
Fixes #39.

I wanted to use [`intra_rustdoc_links`](https://rust-lang.github.io/rfcs/1946-intra-rustdoc-links.html) everywhere to fix the broken links but it looks like proc-macros aren't supported.

So, I used relative paths for in-crate linking (`macro.embed_migrations.html`) and docs.rs urls for cross-crate linking (https://docs.rs/refinery/~0/refinery/macro.embed_migrations.html).