### PR TITLE
Fetch migration version as i64 instead of i32

### DIFF
--- a/refinery/src/drivers/postgres.rs
+++ b/refinery/src/drivers/postgres.rs
@@ -10,7 +10,10 @@ fn query_applied_migrations(
     let rows = transaction.query(query, &[])?;
     let mut applied = Vec::new();
     for row in rows.into_iter() {
-        let version: i32 = row.get(0);
+        let version: i32 = match row.try_get::<_, i32>(0) {
+            Ok(value) => value,
+            Err(_) => row.get::<_, i64>(0) as i32,
+        };
         let applied_on: String = row.get(2);
         let applied_on = DateTime::parse_from_rfc3339(&applied_on)
             .unwrap()

--- a/refinery/src/drivers/tokio_postgres.rs
+++ b/refinery/src/drivers/tokio_postgres.rs
@@ -12,7 +12,10 @@ async fn query_applied_migrations(
     let rows = transaction.query(query, &[]).await?;
     let mut applied = Vec::new();
     for row in rows.into_iter() {
-        let version: i32 = row.get(0);
+        let version: i32 = match row.try_get::<_, i32>(0) {
+            Ok(value) => value,
+            Err(_) => row.get::<_, i64>(0) as i32,
+        };
         let applied_on: String = row.get(2);
         let applied_on = DateTime::parse_from_rfc3339(&applied_on)
             .unwrap()


### PR DESCRIPTION
CockroachDB defaults `INT` fields to `INT8` (64bit), which differs from the postgres behavior. The rust postgres driver panics when fetching the version number with the following message:

	error retrieving column 0: error deserializing column 0: cannot convert
	between the Rust type `i32` and the Postgres type `int8`

Using `i64` instead of `i32` resolves the issue.