### PR TITLE
Add repository for human_panic in cli

### DIFF
--- a/refinery_cli/src/main.rs
+++ b/refinery_cli/src/main.rs
@@ -18,6 +18,7 @@ fn main() -> Result<(), Error> {
         version: VERSION.into(),
         authors: "Katharina Fey <kookie@spacekookie.de>, João Oliveira <hello@jxs.pt>".into(),
         homepage: "https://github.com/rust-db/refinery/".into(),
+        repository: "https://github.com/rust-db/refinery/".into(),
     });
 
     let mut builder = Builder::new();


### PR DESCRIPTION
The 1.0.2 release of the `human_panic` crate adds a `repository` field to the `Metadata` struct. Since the `refinery_cli` crate specifies a version of `1` this new release was being pulled in during a `cargo install`. This was causing the following error for me:

```
error[E0063]: missing field `repository` in initializer of `human_panic::Metadata`
  --> /home/jtdowney/.cargo/registry/src/github.com-1ecc6299db9ec823/refinery_cli-0.2.0/src/main.rs:17:31
   |
17 |     human_panic::setup_panic!(Metadata {
   |                               ^^^^^^^^ missing `repository`

error: aborting due to previous error
```