### PR TITLE
Add note to README about run_async vs run

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Currently [`postgres`](https://crates.io/crates/postgres), [`tokio-postgres`](ht
 - Migrations can be defined in .sql files or Rust modules that must have a function called `migration` that returns a [`String`](https://doc.rust-lang.org/std/string/struct.String.html).
 - Migrations, both .sql files and Rust modules must be named in the format `V{1}__{2}.sql` or `V{1}__{2}.rs`, where `{1}` represents the migration version and `{2}` the name.
 - Migrations can be run either by embedding them in your Rust code with `embed_migrations` and `include_migration_mods` macros, or via `refinery_cli`.
+- If using the `tokio-postgres` feature, use `Runner::run_async()` rather than `Runner::run()`.
 
 ### Example
 ```rust,no_run


### PR DESCRIPTION
Spent about a half an hour wondering why `run` (particualrly `embedded::migrations::runner().run(...)`) wasn't available and after spelunking through the code realized that it must not be compiled in, in favor of `run_async` if you're using `tokio-postgres` (which I am).