### PR TITLE
Support for postgresql uri schema prefix

### DIFF
--- a/refinery_core/src/config.rs
+++ b/refinery_core/src/config.rs
@@ -52,6 +52,7 @@ impl Config {
         let db_type = match url.scheme() {
             "mysql" => ConfigDbType::Mysql,
             "postgres" => ConfigDbType::Postgres,
+            "postgresql" => ConfigDbType::Postgres,
             "sqlite" => ConfigDbType::Sqlite,
             _ => {
                 return Err(Error::new(


### PR DESCRIPTION
Postgres connection URI should also support a `postgresql://` schema as per documentation found here: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING