### PR TITLE
Added ability to create a Config from a string

### DIFF
--- a/refinery_core/src/config.rs
+++ b/refinery_core/src/config.rs
@@ -341,7 +341,7 @@ mod tests {
 
     #[test]
     fn builds_from_str() {
-         let config = Config::from_str("postgres://root:1234@localhost:5432/refinery").unwrap();
+        let config = Config::from_str("postgres://root:1234@localhost:5432/refinery").unwrap();
         assert_eq!(
             "postgres://root:1234@localhost:5432/refinery",
             build_db_url("postgres", &config)


### PR DESCRIPTION
- Added Config::from_str(url_str: &str) #112 
- Refactored Config::from_env_var(...) to call new function (DRY)
- Fixed 'an URL' grammar to 'a URL'
- Fixed a typo in a string: 'environemnt' -> 'environment'