### PR TITLE
warn when migration file name is malformed

### DIFF
--- a/refinery_core/src/util.rs
+++ b/refinery_core/src/util.rs
@@ -44,7 +44,18 @@ pub fn find_migration_files(
         // filter by migration file regex
         .filter(
             move |entry| match entry.file_name().and_then(OsStr::to_str) {
-                Some(file_name) => re.is_match(file_name),
+                Some(file_name) => {
+                    if re.is_match(file_name) {
+                        true
+                    } else {
+                        log::warn!(
+                            "File \"{}\" does not adhere to the migration naming convention. Migrations must be named in the format [U|V]{{1}}__{{2}}.sql or [U|V]{{1}}__{{2}}.rs, where {{1}} represents the migration version and {{2}} the name.",
+                            file_name
+                        );
+
+                        false
+                    }
+                }
                 None => false,
             },
         );


### PR DESCRIPTION
This is my take on warnings for malformed migration names. I wanted to include file name in the warning message as well, hence the condition in Some branch.

Closes: #129 