### PR TITLE
Allow a wider range of rusqlite versions

### DIFF
--- a/refinery_core/Cargo.toml
+++ b/refinery_core/Cargo.toml
@@ -26,7 +26,7 @@ toml = "0.5"
 url = "2.0"
 walkdir = "2.3.1"
 
-rusqlite = {version = ">= 0.23, < 1", optional = true}
+rusqlite = {version = ">= 0.23, < 0.25", optional = true}
 postgres = {version = "0.17", optional = true}
 mysql = {version = "18", optional = true}
 tokio-postgres = { version = "0.5", optional = true }

--- a/refinery_core/Cargo.toml
+++ b/refinery_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "refinery-core"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Katharina Fey <kookie@spacekookie.de>", "João Oliveira <hello@jxs.pt>"]
 description = "This crate should not be used directly, it is internaly related to Refinery"
 license = "MIT OR Apache-2.0"
@@ -26,7 +26,7 @@ toml = "0.5"
 url = "2.0"
 walkdir = "2.3.1"
 
-rusqlite = {version = "0.23", optional = true}
+rusqlite = {version = ">= 0.23, < 1", optional = true}
 postgres = {version = "0.17", optional = true}
 mysql = {version = "18", optional = true}
 tokio-postgres = { version = "0.5", optional = true }


### PR DESCRIPTION
I also tested version `0.24` manually, it passes tests for `cargo test` in the project root directory. If we want to be super-careful here, we could specify the range `>= 0.23, < 0.25` as per cargo documentation: https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#comparison-requirements