### PR TITLE
update postgres and tokio-postgres

### DIFF
--- a/refinery/Cargo.toml
+++ b/refinery/Cargo.toml
@@ -26,7 +26,7 @@ refinery-core= { version = "0.4.0", path = "../refinery_core" }
 refinery-macros= { version = "0.4.0", path = "../refinery_macros" }
 
 [dev-dependencies]
-tokio-compat-02 = "0.1"
+tokio-compat-02 = { git = "https://github.com/LucioFranco/tokio-compat-02.git", branch = "main" }
 barrel = { version = "0.6", features = ["sqlite3", "pg", "mysql"] }
 futures = "0.3"
 assert_cmd = "0.12"

--- a/refinery/Cargo.toml
+++ b/refinery/Cargo.toml
@@ -26,6 +26,7 @@ refinery-core= { version = "0.4.0", path = "../refinery_core" }
 refinery-macros= { version = "0.4.0", path = "../refinery_macros" }
 
 [dev-dependencies]
+tokio-compat-02 = "0.1"
 barrel = { version = "0.6", features = ["sqlite3", "pg", "mysql"] }
 futures = "0.3"
 assert_cmd = "0.12"

--- a/refinery/Cargo.toml
+++ b/refinery/Cargo.toml
@@ -26,7 +26,7 @@ refinery-core= { version = "0.4.0", path = "../refinery_core" }
 refinery-macros= { version = "0.4.0", path = "../refinery_macros" }
 
 [dev-dependencies]
-tokio-compat-02 = { git = "https://github.com/LucioFranco/tokio-compat-02.git", branch = "main" }
+tokio-compat-02 = "~0.1.2"
 barrel = { version = "0.6", features = ["sqlite3", "pg", "mysql"] }
 futures = "0.3"
 assert_cmd = "0.12"

--- a/refinery/tests/mysql_async.rs
+++ b/refinery/tests/mysql_async.rs
@@ -14,6 +14,7 @@ mod mysql_async {
     use refinery_core::mysql_async::prelude::Queryable;
     use refinery_core::{mysql_async, tokio};
     use std::panic::AssertUnwindSafe;
+    use tokio_compat_02::FutureExt as _;
 
     fn get_migrations() -> Vec<Migration> {
         let migration1 = Migration::unapplied(
@@ -65,8 +66,8 @@ mod mysql_async {
     }
 
     async fn run_test<T: std::future::Future<Output = ()>>(t: T) {
-        let result = AssertUnwindSafe(t).catch_unwind().await;
-        clean_database().await;
+        let result = AssertUnwindSafe(t).catch_unwind().compat().await;
+        clean_database().compat().await;
         assert!(result.is_ok());
     }
 

--- a/refinery_core/Cargo.toml
+++ b/refinery_core/Cargo.toml
@@ -32,7 +32,7 @@ mysql = {version = "18", optional = true}
 tokio-postgres = { version = "0.6", optional = true }
 mysql_async = { version = "0.25", optional = true }
 
-tokio = { version = "0.2", features = ["full"], optional = true }
+tokio = { version = "0.3", features = ["full"], optional = true }
 
 [dev-dependencies]
 tempfile = "3.1.0"

--- a/refinery_core/Cargo.toml
+++ b/refinery_core/Cargo.toml
@@ -27,9 +27,9 @@ url = "2.0"
 walkdir = "2.3.1"
 
 rusqlite = {version = ">= 0.23, < 0.25", optional = true}
-postgres = {version = "0.17", optional = true}
+postgres = {version = "0.18", optional = true}
 mysql = {version = "18", optional = true}
-tokio-postgres = { version = "0.5", optional = true }
+tokio-postgres = { version = "0.6", optional = true }
 mysql_async = { version = "0.25", optional = true }
 
 tokio = { version = "0.2", features = ["full"], optional = true }


### PR DESCRIPTION
Thanks for providing this crate!

`postgres` [0.18.1](https://crates.io/crates/postgres/0.18.1) and `tokio-postgres` [0.6.0](https://crates.io/crates/tokio-postgres/0.6.0) are released recently.
It would be straightforward. Please update 😄 