### PR TITLE
Allow 64bit migration versions

### DIFF
--- a/refinery/tests/mysql.rs
+++ b/refinery/tests/mysql.rs
@@ -256,8 +256,8 @@ mod mysql {
             assert_eq!("initial", migrations[0].name());
             assert_eq!("add_cars_table", applied_migrations[1].name());
 
-            assert_eq!(2959965718684201605, applied_migrations[0].checksum());
-            assert_eq!(8238603820526370208, applied_migrations[1].checksum());
+            assert_eq!(13938959368620441626, applied_migrations[0].checksum());
+            assert_eq!(5394706226941044339, applied_migrations[1].checksum());
         });
     }
 

--- a/refinery/tests/mysql_async.rs
+++ b/refinery/tests/mysql_async.rs
@@ -288,8 +288,8 @@ mod mysql_async {
             assert_eq!("initial", migrations[0].name());
             assert_eq!("add_cars_table", applied_migrations[1].name());
 
-            assert_eq!(2959965718684201605, applied_migrations[0].checksum());
-            assert_eq!(8238603820526370208, applied_migrations[1].checksum());
+            assert_eq!(13938959368620441626, applied_migrations[0].checksum());
+            assert_eq!(5394706226941044339, applied_migrations[1].checksum());
         })
         .await
     }

--- a/refinery/tests/postgres.rs
+++ b/refinery/tests/postgres.rs
@@ -264,8 +264,8 @@ mod postgres {
             assert_eq!("initial", migrations[0].name());
             assert_eq!("add_cars_table", applied_migrations[1].name());
 
-            assert_eq!(2959965718684201605, applied_migrations[0].checksum());
-            assert_eq!(8238603820526370208, applied_migrations[1].checksum());
+            assert_eq!(13938959368620441626, applied_migrations[0].checksum());
+            assert_eq!(5394706226941044339, applied_migrations[1].checksum());
         });
     }
 

--- a/refinery/tests/rusqlite.rs
+++ b/refinery/tests/rusqlite.rs
@@ -244,7 +244,7 @@ mod rusqlite {
             .run(&mut conn);
 
         assert!(result.is_err());
-        let query: Option<u32> = conn
+        let query: Option<u64> = conn
             .query_row(
                 "SELECT version FROM refinery_schema_history",
                 NO_PARAMS,

--- a/refinery/tests/rusqlite.rs
+++ b/refinery/tests/rusqlite.rs
@@ -231,8 +231,8 @@ mod rusqlite {
         assert_eq!("initial", migrations[0].name());
         assert_eq!("add_cars_table", applied_migrations[1].name());
 
-        assert_eq!(2959965718684201605, applied_migrations[0].checksum());
-        assert_eq!(8238603820526370208, applied_migrations[1].checksum());
+        assert_eq!(13938959368620441626, applied_migrations[0].checksum());
+        assert_eq!(5394706226941044339, applied_migrations[1].checksum());
     }
 
     #[test]
@@ -244,7 +244,7 @@ mod rusqlite {
             .run(&mut conn);
 
         assert!(result.is_err());
-        let query: Option<u64> = conn
+        let query: Option<i64> = conn
             .query_row(
                 "SELECT version FROM refinery_schema_history",
                 NO_PARAMS,

--- a/refinery/tests/tokio_postgres.rs
+++ b/refinery/tests/tokio_postgres.rs
@@ -358,8 +358,8 @@ mod tokio_postgres {
             assert_eq!("initial", migrations[0].name());
             assert_eq!("add_cars_table", applied_migrations[1].name());
 
-            assert_eq!(2959965718684201605, applied_migrations[0].checksum());
-            assert_eq!(8238603820526370208, applied_migrations[1].checksum());
+            assert_eq!(13938959368620441626, applied_migrations[0].checksum());
+            assert_eq!(5394706226941044339, applied_migrations[1].checksum());
         })
         .await
     }

--- a/refinery_core/src/drivers/mysql_async.rs
+++ b/refinery_core/src/drivers/mysql_async.rs
@@ -15,7 +15,7 @@ async fn query_applied_migrations<'a>(
     let applied = result
         .into_iter()
         .map(|row| {
-            let (version, name, applied_on, checksum): (i32, String, String, String) =
+            let (version, name, applied_on, checksum): (i64, String, String, String) =
                 mysql_async::from_row(row);
 
             let applied_on = DateTime::parse_from_rfc3339(&applied_on)

--- a/refinery_core/src/runner.rs
+++ b/refinery_core/src/runner.rs
@@ -50,7 +50,7 @@ impl fmt::Debug for Type {
 #[derive(Clone, Copy)]
 pub enum Target {
     Latest,
-    Version(u32),
+    Version(u64),
 }
 
 // an Enum set that represents the state of the migration: Applied on the database,
@@ -72,7 +72,7 @@ pub struct Migration {
     state: State,
     name: String,
     checksum: u64,
-    version: i32,
+    version: i64,
     prefix: Type,
     sql: Option<String>,
     applied_on: Option<DateTime<Local>>,
@@ -86,7 +86,7 @@ impl Migration {
             .captures(input_name)
             .filter(|caps| caps.len() == 4)
             .ok_or_else(|| Error::new(Kind::InvalidName, None))?;
-        let version: i32 = captures[2]
+        let version: i64 = captures[2]
             .parse()
             .map_err(|_| Error::new(Kind::InvalidVersion, None))?;
 
@@ -124,7 +124,7 @@ impl Migration {
 
     // Create a migration from an applied migration on the database
     pub(crate) fn applied(
-        version: i32,
+        version: i64,
         name: String,
         applied_on: DateTime<Local>,
         checksum: u64,
@@ -153,8 +153,8 @@ impl Migration {
     }
 
     /// Get the Migration version
-    pub fn version(&self) -> u32 {
-        self.version as u32
+    pub fn version(&self) -> u64 {
+        self.version as u64
     }
 
     /// Get the Prefix

--- a/refinery_core/src/traits/mod.rs
+++ b/refinery_core/src/traits/mod.rs
@@ -46,10 +46,10 @@ pub(crate) fn verify_migrations(
         }
     }
 
-    let current: i32 = match applied.last() {
+    let current: i64 = match applied.last() {
         Some(last) => {
             log::info!("current version: {}", last.version());
-            last.version() as i32
+            last.version() as i64
         }
         None => {
             log::info!("schema history table is empty, going to apply all migrations");
@@ -71,7 +71,7 @@ pub(crate) fn verify_migrations(
             if to_be_applied.contains(&migration) {
                 return Err(Error::new(Kind::RepeatedVersion(migration), None));
             } else if migration.prefix() == &Type::Versioned
-                && current >= migration.version() as i32
+                && current >= migration.version() as i64
             {
                 if abort_missing {
                     return Err(Error::new(Kind::MissingVersion(migration), None));
@@ -91,7 +91,7 @@ pub(crate) fn verify_migrations(
 
 pub(crate) const ASSERT_MIGRATIONS_TABLE_QUERY: &str =
     "CREATE TABLE IF NOT EXISTS refinery_schema_history( \
-             version INT4 PRIMARY KEY,\
+             version INT8 PRIMARY KEY,\
              name VARCHAR(255),\
              applied_on VARCHAR(255),
              checksum VARCHAR(255));";


### PR DESCRIPTION
This should allow the versions to be parsed and inserted into the database.

I still need to add a command to the CLI to generate a migration for each supported database.

fixes #83