### PR TITLE
feat: make traits module public

### DIFF
--- a/refinery_core/src/lib.rs
+++ b/refinery_core/src/lib.rs
@@ -2,7 +2,7 @@ pub mod config;
 mod drivers;
 pub mod error;
 mod runner;
-mod traits;
+pub mod traits;
 mod util;
 
 pub use crate::error::Error;


### PR DESCRIPTION
This patch makes the traits module public, so third-party migration
implementations can be supported.

Fixes #155