### PR TITLE
Bump rusqlite version

### DIFF
--- a/refinery/tests/rusqlite.rs
+++ b/refinery/tests/rusqlite.rs
@@ -12,7 +12,7 @@ mod rusqlite {
         error::Kind,
         Migrate, Migration, Runner, Target,
     };
-    use refinery_core::rusqlite::{Connection, OptionalExtension, NO_PARAMS};
+    use refinery_core::rusqlite::{Connection, OptionalExtension};
     use std::fs::{self, File};
     use std::process::Command;
 
@@ -112,7 +112,7 @@ mod rusqlite {
         let table_name: String = conn
             .query_row(
                 "SELECT name FROM sqlite_master WHERE type='table' AND name='refinery_schema_history'",
-                NO_PARAMS,
+                [],
                 |row| row.get(0),
             )
             .unwrap();
@@ -129,7 +129,7 @@ mod rusqlite {
         let table_name: String = conn
             .query_row(
                 "SELECT name FROM sqlite_master WHERE type='table' AND name='refinery_schema_history'",
-                NO_PARAMS,
+                [],
                 |row| row.get(0),
             )
             .unwrap();
@@ -148,7 +148,7 @@ mod rusqlite {
         )
         .unwrap();
         let (name, city): (String, String) = conn
-            .query_row("SELECT name, city FROM persons", NO_PARAMS, |row| {
+            .query_row("SELECT name, city FROM persons", [], |row| {
                 Ok((row.get(0).unwrap(), row.get(1).unwrap()))
             })
             .unwrap();
@@ -171,7 +171,7 @@ mod rusqlite {
         )
         .unwrap();
         let (name, city): (String, String) = conn
-            .query_row("SELECT name, city FROM persons", NO_PARAMS, |row| {
+            .query_row("SELECT name, city FROM persons", [], |row| {
                 Ok((row.get(0).unwrap(), row.get(1).unwrap()))
             })
             .unwrap();
@@ -245,11 +245,9 @@ mod rusqlite {
 
         assert!(result.is_err());
         let query: Option<u32> = conn
-            .query_row(
-                "SELECT version FROM refinery_schema_history",
-                NO_PARAMS,
-                |row| row.get(0),
-            )
+            .query_row("SELECT version FROM refinery_schema_history", [], |row| {
+                row.get(0)
+            })
             .optional()
             .unwrap();
         assert!(query.is_none());
@@ -262,7 +260,7 @@ mod rusqlite {
         let table_name: String = conn
             .query_row(
                 "SELECT name FROM sqlite_master WHERE type='table' AND name='refinery_schema_history'",
-                NO_PARAMS,
+                [],
                 |row| row.get(0),
             )
             .unwrap();
@@ -281,7 +279,7 @@ mod rusqlite {
         )
         .unwrap();
         let (name, city): (String, String) = conn
-            .query_row("SELECT name, city FROM persons", NO_PARAMS, |row| {
+            .query_row("SELECT name, city FROM persons", [], |row| {
                 Ok((row.get(0).unwrap(), row.get(1).unwrap()))
             })
             .unwrap();

--- a/refinery_core/Cargo.toml
+++ b/refinery_core/Cargo.toml
@@ -26,7 +26,7 @@ toml = "0.5"
 url = "2.0"
 walkdir = "2.3.1"
 
-rusqlite = {version = ">= 0.23, < 0.25", optional = true}
+rusqlite = {version = ">= 0.23, < 0.26", optional = true}
 postgres = {version = "0.19", optional = true}
 mysql = {version = "20", optional = true}
 tokio-postgres = { version = "0.7", optional = true }

--- a/refinery_core/src/drivers/rusqlite.rs
+++ b/refinery_core/src/drivers/rusqlite.rs
@@ -1,14 +1,14 @@
 use crate::traits::sync::{Migrate, Query, Transaction};
 use crate::Migration;
 use chrono::{DateTime, Local};
-use rusqlite::{Connection as RqlConnection, Error as RqlError, NO_PARAMS};
+use rusqlite::{Connection as RqlConnection, Error as RqlError};
 
 fn query_applied_migrations(
     transaction: &RqlConnection,
     query: &str,
 ) -> Result<Vec<Migration>, RqlError> {
     let mut stmt = transaction.prepare(query)?;
-    let mut rows = stmt.query(NO_PARAMS)?;
+    let mut rows = stmt.query([])?;
     let mut applied = Vec::new();
     while let Some(row) = rows.next()? {
         let version = row.get(0)?;


### PR DESCRIPTION
The new version doesn't seem to come with breaking changes regarding this project. The only difference is the fact that they've deprecated the `NO_PARAMS` constant in favour of just using an empty array.