### PR TITLE
Update rusqlite to include latest 0.26.x

### DIFF
--- a/refinery_core/Cargo.toml
+++ b/refinery_core/Cargo.toml
@@ -30,7 +30,7 @@ toml = "0.5"
 url = "2.0"
 walkdir = "2.3.1"
 
-rusqlite = { version = ">= 0.23, < 0.26", optional = true }
+rusqlite = { version = ">= 0.23, < 0.27", optional = true }
 postgres = { version = "0.19", optional = true }
 tokio-postgres-driver = { package = "tokio-postgres", version = "0.7", optional = true }
 mysql = { version = "21.0.0", optional = true }


### PR DESCRIPTION
Bump version requirement for `rusqlite` to allow for the latest `0.26.x` version.
