### PR TITLE
Updated mysql and disabled default features

### DIFF
--- a/refinery_core/Cargo.toml
+++ b/refinery_core/Cargo.toml
@@ -33,13 +33,14 @@ walkdir = "2.3.1"
 rusqlite = { version = ">= 0.23, <= 0.26", optional = true }
 postgres = { version = "0.19", optional = true }
 tokio-postgres-driver = { package = "tokio-postgres", version = "0.7", optional = true }
-mysql = { version = "21.0.0", optional = true }
+mysql = { version = "22.0.0", optional = true, default-features = false}
 mysql-async-driver = { package = "mysql_async", version = ">= 0.28, <= 0.29", optional = true }
 tokio = { version = "1.0", features = ["full"], optional = true }
 tiberius-driver = { package = "tiberius", version = "0.6", optional = true }
 futures = { version = "0.3.16", optional = true }
 tokio-util = { version = "0.6.7", features = ["compat"], optional = true }
 time = { version = "0.3.5", features = ["parsing", "formatting"] }
+flate2 = { version = "1.0", default-features = false, features = [ "zlib" ]}
 
 [dev-dependencies]
 barrel = { git = "https://github.com/jxs/barrel", features = ["sqlite3", "pg", "mysql", "mssql"] }


### PR DESCRIPTION
## Changes
- Bumped mysql to v22.0.0
- Disabled default features on mysql
- Added flate2 crate with zlib feature, This previously came in via the mysql crate but now it no longer is, so it must be specified by us

## Reasoning
MySQL default ships with `native-tls`, i.e. OpenSSL enabled by default. My [PR](https://github.com/blackbeam/rust-mysql-simple/pull/293) to the `mysql` crate makes this optional but keeps OpenSSL enabled by default. However, when using `refinery` it is still pulled in, even if it is not enabled in my binary crate due to the way Cargo resolves features.

This PR makes `mysql` features optional, allowing the end user to choose if they want `native-tls`, or `rustls` e.g. By default `mysql` also came with the feature `flate2/zlib`, with disabled default features `flate2/zlib` is no longer included. When using `refinery` with only the `mysql` feature enabled it compiles fine. However, with the default feature set it no longer does (`cargo b` fails with too many errors to count). 

## Backwards compatibility
Backwards compatibility is maintained as the `OpenSSL` feature is still enabled by default via the `mysql` crate.

Thanks
