### PR TITLE
Expand rusqlite dependency spec to include latest release

### DIFF
--- a/refinery_core/Cargo.toml
+++ b/refinery_core/Cargo.toml
@@ -30,7 +30,7 @@ url = "2.0"
 walkdir = "2.3.1"
 
 # allow multiple versions of the same dependency if API is similar
-rusqlite = { version = ">= 0.23, <= 0.26", optional = true }
+rusqlite = { version = ">= 0.23, <= 0.27", optional = true }
 postgres = { version = "0.19", optional = true }
 tokio-postgres-driver = { package = "tokio-postgres", version = "0.7", optional = true }
 mysql = { version = ">= 21.0.0, <= 22", optional = true, default-features = false}


### PR DESCRIPTION
Rusqlite released 0.27.0 not quite three weeks ago. Looks like all the refinery tests pass against the latest release, and glancing at the release diff I didn't notice any breaking changes. So this PR updates the rusqlite dependency spec to permit the new 0.27.0 version.