### PR TITLE
Evolve[Doc]: Sequential and Non-sequential

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ Powerful SQL migration toolkit for Rust.
 </div>
 <br/>
 
-`refinery` makes running migrations for different databases as easy as possible.
-It works by running your migrations on a provided database connection, either by embedding them on your Rust code, or via `refinery_cli`.
+Refinery makes running migrations for different databases as easy as possible.
+It works by running your migrations on a provided database connection, either by embedding them on your Rust code, or via `refinery` CLI.
 Currently [`postgres`](https://crates.io/crates/postgres), [`tokio-postgres`](https://crates.io/crates/tokio-postgres) , [`mysql`](https://crates.io/crates/mysql), [`mysql_async`](https://crates.io/crates/mysql_async), [`rusqlite`](https://crates.io/crates/rusqlite) and [`tiberius`](https://github.com/prisma/tiberius) are supported.\
 If you are using a driver that is not yet supported, namely [`SQLx`](https://github.com/launchbadge/sqlx) you can run migrations providing a [`Config`](https://docs.rs/refinery/latest/refinery/config/struct.Config.html) instead of the connection type, as `Config` impl's `Migrate`. You will still need to provide the `postgres`/`mysql`/`rusqlite`/`tiberius` driver as a feature for [`Runner::run`](https://docs.rs/refinery/latest/refinery/struct.Runner.html#method.run) and `tokio-postgres`/`mysql_async` for [`Runner::run_async`](https://docs.rs/refinery/latest/refinery/struct.Runner.html#method.run_async).\
-`refinery` works best with [`Barrel`](https://crates.io/crates/barrel) but you can also have your migrations in .sql files or use any other Rust crate for schema generation.
+`refinery` works best with [`Barrel`](https://crates.io/crates/barrel) but you can also have your migrations in `.sql` files or use any other Rust crate for schema generation.
 
 ## Usage
 
@@ -32,9 +32,9 @@ If you are using a driver that is not yet supported, namely [`SQLx`](https://git
 - Migrations can be defined in .sql files or Rust modules that must have a function called `migration` that returns a [`String`](https://doc.rust-lang.org/std/string/struct.String.html).
 - Migrations can be strictly versioned by prefixing the file with `V` or not strictly versioned by prefixing the file with `U`.
 - Migrations, both .sql files and Rust modules must be named in the format `[U|V]{1}__{2}.sql` or `[U|V]{1}__{2}.rs`, where `{1}` represents the migration version and `{2}` the name.
-- Migrations can be run either by embedding them in your Rust code with `embed_migrations` macro, or via `refinery_cli`.
+- Migrations can be run either by embedding them in your Rust code with `embed_migrations` macro, or via `refinery` CLI`.
 
-### Example
+### Example: Library
 ```rust,no_run
 use rusqlite::Connection;
 
@@ -49,18 +49,33 @@ fn main() {
 }
 ```
 
-For more examples, refer to the [`examples`](examples).
+For more library examples, refer to the [`examples`](examples).
 
-### Unversioned VS Versioned migrations
+### Example: CLI
 
-Depending on how your project / team has been structured will define whether you want to use Versioned migrations `V{1}__{2}.[sql|rs]` or Unversioned migrations `U{1}__{2}.[sql|rs]`.
-If all migrations are created synchronously and are deployed synchronously you won't run into any problems using Versioned migrations.
+NOTE: 
+
+- Sequential migration version numbers are restricted to `u32` (unsigned, 32-bit integers).
+- Non-sequential migration version numbers are restricted to `u32` (unsigned, 32-bit integers).
+
+```bash
+export DATABASE_URL="postgres://postgres:secret@localhost:5432/your-db"
+pushd migrations
+    # Runs ./src/V1__*.rs or ./src/V1__*.sql 
+    refinery migrate -e DATABASE_URL -p ./src -t 1
+popd
+```
+
+### Non-sequential VS Sequential migrations
+
+Depending on how your project / team has been structured will define whether you want to use sequential migrations `V{1}__{2}.[sql|rs]` or non-sequential migrations `U{1}__{2}.[sql|rs]`.
+If all migrations are created synchronously and are deployed synchronously you won't run into any problems using Sequential migrations.
 This is because you can be sure the next migration being run is _always_ going to have a version number greater than the previous.
 
-With Unversioned migrations there is more flexibility in the order that the migrations can be created and deployed.
+With Non-sequential migrations there is more flexibility in the order that the migrations can be created and deployed.
 If developer 1 creates a PR with a migration today `U11__update_cars_table.sql`, but it is reviewed for a week.
 Meanwhile, developer 2 creates a PR with migration `U12__create_model_tags.sql` that is much simpler and gets merged and deployed immediately.
-This would stop developer 1's migration from ever running if you were using Versioned migrations because the next migration would need to be > 12.
+This would stop developer 1's migration from ever running if you were using Sequential migrations because the next migration would need to be > 12.
 
 ## Implementation details
 


### PR DESCRIPTION
The existing Versioned and Unversioned adjectives lead to this type of sentence:

> Unversioned migration version numbers are restricted to `u32` (unsigned, 32-bit integers).

This seems less contradictory:

> Non-sequential migration version numbers are restricted to `u32` (unsigned, 32-bit integers).