### PR TITLE
Add compatibility with mysql_async 0.30.0 (#229)

### DIFF
--- a/refinery_core/Cargo.toml
+++ b/refinery_core/Cargo.toml
@@ -34,7 +34,7 @@ rusqlite = { version = ">= 0.23, <= 0.27", optional = true }
 postgres = { version = "0.19", optional = true }
 tokio-postgres-driver = { package = "tokio-postgres", version = "0.7", optional = true }
 mysql = { version = ">= 21.0.0, <= 22", optional = true, default-features = false}
-mysql-async-driver = { package = "mysql_async", version = ">= 0.28, <= 0.29", optional = true }
+mysql-async-driver = { package = "mysql_async", version = ">= 0.28, <= 0.30", optional = true }
 tokio = { version = "1.0", features = ["full"], optional = true }
 tiberius-driver = { package = "tiberius", version = "0.7", optional = true }
 futures = { version = "0.3.16", optional = true }

--- a/refinery_core/src/drivers/mysql_async.rs
+++ b/refinery_core/src/drivers/mysql_async.rs
@@ -47,7 +47,7 @@ impl AsyncTransaction for Pool {
         let mut transaction = conn.start_transaction(options).await?;
         let mut count = 0;
         for query in queries {
-            transaction.query_drop(query).await?;
+            transaction.query_drop(*query).await?;
             count += 1;
         }
         transaction.commit().await?;


### PR DESCRIPTION
Two open questions with this one:
1: compiling with mysql_async 0.28.1 doesn't work. 0.28 is fine, 0.29 and greater are fine too.
Error: 
```
error[E0432]: unresolved import `mio::net`
  --> C:\Users\local\.cargo\registry\src\github.com-1ecc6299db9ec823\mysql_async-0.28.1\src\io\mod.rs:14:10
   |
14 | use mio::net::{TcpKeepalive, TcpSocket};
   |          ^^^ could not find `net` in `mio`

error[E0599]: no function or associated item named `new` found for struct `mio::Poll` in the current scope
   --> C:\Users\local\.cargo\registry\src\github.com-1ecc6299db9ec823\mysql_async-0.28.1\src\io\mod.rs:378:43
    |
378 |                 let mut poll = mio::Poll::new()?;
    |                                           ^^^ function or associated item not found in `mio::Poll`

Some errors have detailed explanations: E0432, E0599.
For more information about an error, try `rustc --explain E0432`.
error: could not compile `mysql_async` due to 2 previous errors
warning: build failed, waiting for other jobs to finish...
```

2: There are some warnings about unused code. I'm not sure if the code is required by other features, so I left them as they were.

```
warning: unused import: `ConfigDbType`
 --> C:\Users\local\Desktop\Daten\Programme\refinery\refinery_core\src\drivers\config.rs:8:29
  |
8 | use crate::config::{Config, ConfigDbType};
  |                             ^^^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

warning: unused import: `crate::error::WrapMigrationError`
 --> C:\Users\local\Desktop\Daten\Programme\refinery\refinery_core\src\drivers\config.rs:9:5
  |
9 | use crate::error::WrapMigrationError;
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: unused imports: `GET_APPLIED_MIGRATIONS_QUERY`, `GET_LAST_APPLIED_MIGRATION_QUERY`
  --> C:\Users\local\Desktop\Daten\Programme\refinery\refinery_core\src\drivers\config.rs:12:21
   |
12 | use crate::traits::{GET_APPLIED_MIGRATIONS_QUERY, GET_LAST_APPLIED_MIGRATION_QUERY};
   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: unused imports: `Error`, `Report`, `Target`
  --> C:\Users\local\Desktop\Daten\Programme\refinery\refinery_core\src\drivers\config.rs:13:13
   |
13 | use crate::{Error, Migration, Report, Target};
   |             ^^^^^             ^^^^^^  ^^^^^^

warning: associated function is never used: `applied`
   --> C:\Users\local\Desktop\Daten\Programme\refinery\refinery_core\src\runner.rs:128:19
    |
128 |     pub(crate) fn applied(
    |                   ^^^^^^^
    |
    = note: `#[warn(dead_code)]` on by default

warning: `refinery-core` (lib) generated 5 warnings
```