### PR TITLE
Cargo publish CI

### DIFF
--- a/.github/workflows/cargo-publish.yaml
+++ b/.github/workflows/cargo-publish.yaml
@@ -15,16 +15,43 @@ jobs:
     - name: Checkout source
       uses: actions/checkout@v3
 
-    - name: cargo publish
-
-    
+    - name: Setup toolchain
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
 
-    - uses: actions-rs/cargo@v1
+    - name: Publish refinery-core
+      uses: actions-rs/cargo@v1
       env:
         CARGO_TOKEN: ${{ secrets.CARGO_TOKEN }}
       with:
         command: publish
+        args: --all-features refinery-core
+        args: --token $CARGO_TOKEN
+
+    - name: Publish refinery-macros
+      uses: actions-rs/cargo@v1
+      env:
+        CARGO_TOKEN: ${{ secrets.CARGO_TOKEN }}
+      with:
+        command: publish
+        args: --all-features refinery-macros
+        args: --token $CARGO_TOKEN
+
+    - name: Publish refinery
+      uses: actions-rs/cargo@v1
+      env:
+        CARGO_TOKEN: ${{ secrets.CARGO_TOKEN }}
+      with:
+        command: publish
+        args: --all-features refinery
+        args: --token $CARGO_TOKEN
+
+    - name: Publish refinery-cli
+      uses: actions-rs/cargo@v1
+      env:
+        CARGO_TOKEN: ${{ secrets.CARGO_TOKEN }}
+      with:
+        command: publish
+        args: --all-features refinery-cli
         args: --token $CARGO_TOKEN

--- a/.github/workflows/cargo-publish.yaml
+++ b/.github/workflows/cargo-publish.yaml
@@ -1,0 +1,30 @@
+name: Publish a release to crates.io
+
+on:
+  push:
+    branches:
+      - 'main'
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+"
+
+jobs:
+  upload-crate:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout source
+      uses: actions/checkout@v3
+
+    - name: cargo publish
+
+    
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+
+    - uses: actions-rs/cargo@v1
+      env:
+        CARGO_TOKEN: ${{ secrets.CARGO_TOKEN }}
+      with:
+        command: publish
+        args: --token $CARGO_TOKEN


### PR DESCRIPTION
Closes #236 

This PR adds a CI that's run on a Git tag, it'll publish the crate to crates.io.
The `CARGO_TOKEN` secret must be set to a crates.io access token. This Action uses GitHub secrets for the token.

The action does not validate that the Git tag matches the configured version in the crate, nor does it run tests. The tag is assumed to be validated manually. Tests should be run on CI before a tag is created.

Thanks.