### PR TITLE
Unseal Migration::sql() getter

### DIFF
--- a/refinery_core/src/runner.rs
+++ b/refinery_core/src/runner.rs
@@ -150,7 +150,7 @@ impl Migration {
     }
 
     // Get migration sql content
-    pub(crate) fn sql(&self) -> Option<&str> {
+    pub fn sql(&self) -> Option<&str> {
         self.sql.as_deref()
     }
 


### PR DESCRIPTION
Makes `sql()` method public, allowing read access to the raw sql of a migration.

See related issue #247 for details.