### PR TITLE
Support `mysql` v`23`

### DIFF
--- a/.github/workflows/cargo-publish.yaml
+++ b/.github/workflows/cargo-publish.yaml
@@ -15,16 +15,43 @@ jobs:
     - name: Checkout source
       uses: actions/checkout@v3
 
-    - name: cargo publish
-
-    
+    - name: Setup toolchain
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
 
-    - uses: actions-rs/cargo@v1
+    - name: Publish refinery-core
+      uses: actions-rs/cargo@v1
       env:
         CARGO_TOKEN: ${{ secrets.CARGO_TOKEN }}
       with:
         command: publish
+        args: --all-features refinery-core
+        args: --token $CARGO_TOKEN
+
+    - name: Publish refinery-macros
+      uses: actions-rs/cargo@v1
+      env:
+        CARGO_TOKEN: ${{ secrets.CARGO_TOKEN }}
+      with:
+        command: publish
+        args: --all-features refinery-macros
+        args: --token $CARGO_TOKEN
+
+    - name: Publish refinery
+      uses: actions-rs/cargo@v1
+      env:
+        CARGO_TOKEN: ${{ secrets.CARGO_TOKEN }}
+      with:
+        command: publish
+        args: --all-features refinery
+        args: --token $CARGO_TOKEN
+
+    - name: Publish refinery-cli
+      uses: actions-rs/cargo@v1
+      env:
+        CARGO_TOKEN: ${{ secrets.CARGO_TOKEN }}
+      with:
+        command: publish
+        args: --all-features refinery-cli
         args: --token $CARGO_TOKEN

--- a/.github/workflows/cargo-publish.yaml
+++ b/.github/workflows/cargo-publish.yaml
@@ -1,0 +1,30 @@
+name: Publish a release to crates.io
+
+on:
+  push:
+    branches:
+      - 'main'
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+"
+
+jobs:
+  upload-crate:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout source
+      uses: actions/checkout@v3
+
+    - name: cargo publish
+
+    
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+
+    - uses: actions-rs/cargo@v1
+      env:
+        CARGO_TOKEN: ${{ secrets.CARGO_TOKEN }}
+      with:
+        command: publish
+        args: --token $CARGO_TOKEN

--- a/refinery_core/Cargo.toml
+++ b/refinery_core/Cargo.toml
@@ -33,7 +33,7 @@ walkdir = "2.3.1"
 rusqlite = { version = ">= 0.23, <= 0.28", optional = true }
 postgres = { version = "0.19", optional = true }
 tokio-postgres = { version = "0.7", optional = true }
-mysql = { version = ">= 21.0.0, <= 22", optional = true, default-features = false}
+mysql = { version = ">= 21.0.0, <= 23", optional = true, default-features = false}
 mysql_async = { version = ">= 0.28, <= 0.30", optional = true }
 tokio = { version = "1.0", features = ["full"], optional = true }
 tiberius = { version = "0.7", optional = true }


### PR DESCRIPTION
This PR updates the dependency constraints for `mysql`, allowing v`23`

Relevant issue: #255 