### PR TITLE
Allow loggers to better filter errors in the refinery_core/trait

### DIFF
--- a/refinery_core/src/traits/mod.rs
+++ b/refinery_core/src/traits/mod.rs
@@ -24,7 +24,7 @@ pub(crate) fn verify_migrations(
                 if abort_missing {
                     return Err(Error::new(Kind::MissingVersion(app.clone()), None));
                 } else {
-                    log::error!("migration {} is missing from the filesystem", app);
+                    log::error!(target: "refinery_core::traits::missing", "migration {} is missing from the filesystem", app);
                 }
             }
             Some(migration) => {
@@ -36,6 +36,7 @@ pub(crate) fn verify_migrations(
                         ));
                     } else {
                         log::error!(
+                            target: "refinery_core::traits::divergent",
                             "applied migration {} is different than filesystem one {}",
                             app,
                             migration
@@ -75,7 +76,7 @@ pub(crate) fn verify_migrations(
                 if abort_missing {
                     return Err(Error::new(Kind::MissingVersion(migration), None));
                 } else {
-                    log::error!("found migration on file system {} not applied", migration);
+                    log::error!(target: "refinery_core::traits::missing", "found migration on file system {} not applied", migration);
                 }
             } else {
                 to_be_applied.push(migration);


### PR DESCRIPTION
add a manual target to those errors, as some people want to completely ignore them and don't even log in that case.

In order to stay compatible with existing errors, we just append a missing or divergent to the path. So logging crates can easily apply filters if they want to, but they don't have to.