### PR TITLE
_RECOMPILE_IF_CHANGED to appease rust-analyzer

### DIFF
--- a/refinery_macros/src/lib.rs
+++ b/refinery_macros/src/lib.rs
@@ -77,7 +77,7 @@ pub fn embed_migrations(input: TokenStream) -> TokenStream {
             let mig_mod = quote! {pub mod #ident {
                 #rs_content
                 // also include the file as str so we trigger recompilation if it changes
-                const _recompile_if_changed: &str = include_str!(#path);
+                const _RECOMPILE_IF_CHANGED: &str = include_str!(#path);
             }};
             _migrations.push(quote! {(#filename, #ident::migration())});
             migrations_mods.push(mig_mod);


### PR DESCRIPTION
Upcase `_recompile_if_changed` in order to appease `rust-analyzer`, as the former is seen as a global constant by the latter.