### PR TITLE
Runner IntoIterator support

### DIFF
--- a/examples/main.rs
+++ b/examples/main.rs
@@ -7,5 +7,12 @@ mod embedded {
 
 fn main() {
     let mut conn = Connection::open_in_memory().unwrap();
-    embedded::migrations::runner().run(&mut conn).unwrap();
+    embedded::migrations::runner(&mut conn).run().unwrap();
+}
+
+fn iter_main() {
+    let mut conn = Connection::open_in_memory().unwrap();
+    for migration in embedded::migrations::runner(&mut conn) {
+        info!("Got a migration: {}", migration.expect("migration failed!"));
+    }
 }

--- a/refinery/tests/mysql.rs
+++ b/refinery/tests/mysql.rs
@@ -92,7 +92,7 @@ mod mysql {
                 .unwrap();
             let pool = mysql::Pool::new(opts).unwrap();
             let mut conn = pool.get_conn().unwrap();
-            let report = embedded::migrations::runner().run(&mut conn).unwrap();
+            let report = embedded::migrations::runner(&mut conn).run().unwrap();
 
             let migrations = get_migrations();
             let applied_migrations = report.applied_migrations();
@@ -123,7 +123,7 @@ mod mysql {
                 .unwrap();
             let pool = mysql::Pool::new(opts).unwrap();
             let mut conn = pool.get_conn().unwrap();
-            embedded::migrations::runner().run(&mut conn).unwrap();
+            embedded::migrations::runner(&mut conn).run().unwrap();
             for row in format!(
                 "SELECT table_name FROM information_schema.tables WHERE table_name='{}'",
                 DEFAULT_TABLE_NAME
@@ -144,9 +144,9 @@ mod mysql {
                 .unwrap();
             let pool = mysql::Pool::new(opts).unwrap();
             let mut conn = pool.get_conn().unwrap();
-            embedded::migrations::runner()
+            embedded::migrations::runner(&mut conn)
                 .set_grouped(false)
-                .run(&mut conn)
+                .run()
                 .unwrap();
 
             for row in format!(
@@ -170,7 +170,7 @@ mod mysql {
             let pool = mysql::Pool::new(opts).unwrap();
             let mut conn = pool.get_conn().unwrap();
 
-            embedded::migrations::runner().run(&mut conn).unwrap();
+            embedded::migrations::runner(&mut conn).run().unwrap();
             "INSERT INTO persons (name, city) VALUES ('John Legend', 'New York')"
                 .run(&mut conn)
                 .unwrap();
@@ -192,9 +192,9 @@ mod mysql {
             let pool = mysql::Pool::new(opts).unwrap();
             let mut conn = pool.get_conn().unwrap();
 
-            embedded::migrations::runner()
+            embedded::migrations::runner(&mut conn)
                 .set_grouped(false)
-                .run(&mut conn)
+                .run()
                 .unwrap();
 
             "INSERT INTO persons (name, city) VALUES ('John Legend', 'New York')"
@@ -218,7 +218,7 @@ mod mysql {
             let pool = mysql::Pool::new(opts).unwrap();
             let mut conn = pool.get_conn().unwrap();
 
-            embedded::migrations::runner().run(&mut conn).unwrap();
+            embedded::migrations::runner(&mut conn).run().unwrap();
             let current = conn
                 .get_last_applied_migration(DEFAULT_TABLE_NAME)
                 .unwrap()
@@ -240,12 +240,12 @@ mod mysql {
             let pool = mysql::Pool::new(opts).unwrap();
             let mut conn = pool.get_conn().unwrap();
 
-            embedded::migrations::runner()
+            embedded::migrations::runner(&mut conn)
                 .set_grouped(false)
-                .run(&mut conn)
+                .run()
                 .unwrap();
 
-            embedded::migrations::runner().run(&mut conn).unwrap();
+            embedded::migrations::runner(&mut conn).run().unwrap();
             let current = conn
                 .get_last_applied_migration(DEFAULT_TABLE_NAME)
                 .unwrap()
@@ -267,7 +267,7 @@ mod mysql {
             let pool = mysql::Pool::new(opts).unwrap();
             let mut conn = pool.get_conn().unwrap();
 
-            let result = broken::migrations::runner().run(&mut conn);
+            let result = broken::migrations::runner(&mut conn).run();
 
             assert!(result.is_err());
 
@@ -306,7 +306,7 @@ mod mysql {
     //         let pool = mysql::Pool::new("mysql://refinery:root@localhost:3306/refinery_test").unwrap();
     //         let mut conn = pool.get_conn().unwrap();
 
-    //         let result = broken::migrations::runner().set_grouped(true).run(&mut conn);
+    //         let result = broken::migrations::runner(&mut conn).set_grouped(true).run();
 
     //         assert!(result.is_err());
 
@@ -329,7 +329,7 @@ mod mysql {
             let pool = mysql::Pool::new(opts).unwrap();
             let mut conn = pool.get_conn().unwrap();
 
-            embedded::migrations::runner().run(&mut conn).unwrap();
+            embedded::migrations::runner(&mut conn).run().unwrap();
 
             let migrations = get_migrations();
             let applied_migrations = conn.get_applied_migrations(DEFAULT_TABLE_NAME).unwrap();
@@ -360,7 +360,7 @@ mod mysql {
             let pool = mysql::Pool::new(opts).unwrap();
             let mut conn = pool.get_conn().unwrap();
 
-            embedded::migrations::runner().run(&mut conn).unwrap();
+            embedded::migrations::runner(&mut conn).run().unwrap();
             let migrations = get_migrations();
 
             let mchecksum = migrations[4].checksum();
@@ -392,9 +392,9 @@ mod mysql {
             let pool = mysql::Pool::new(opts).unwrap();
             let mut conn = pool.get_conn().unwrap();
 
-            let report = embedded::migrations::runner()
+            let report = embedded::migrations::runner(&mut conn)
                 .set_target(Target::Version(3))
-                .run(&mut conn)
+                .run()
                 .unwrap();
 
             let current = conn
@@ -430,10 +430,10 @@ mod mysql {
             let pool = mysql::Pool::new(opts).unwrap();
             let mut conn = pool.get_conn().unwrap();
 
-            let report = embedded::migrations::runner()
+            let report = embedded::migrations::runner(&mut conn)
                 .set_target(Target::Version(3))
                 .set_grouped(true)
-                .run(&mut conn)
+                .run()
                 .unwrap();
 
             let current = conn
@@ -468,7 +468,7 @@ mod mysql {
             let pool = mysql::Pool::new(opts).unwrap();
             let mut conn = pool.get_conn().unwrap();
 
-            embedded::migrations::runner().run(&mut conn).unwrap();
+            embedded::migrations::runner(&mut conn).run().unwrap();
 
             let migration = Migration::unapplied(
                 "V4__add_year_field_to_cars",
@@ -504,7 +504,7 @@ mod mysql {
             let pool = mysql::Pool::new(opts).unwrap();
             let mut conn = pool.get_conn().unwrap();
 
-            embedded::migrations::runner().run(&mut conn).unwrap();
+            embedded::migrations::runner(&mut conn).run().unwrap();
 
             let migration = Migration::unapplied(
                 "V2__add_year_field_to_cars",
@@ -541,7 +541,7 @@ mod mysql {
             let pool = mysql::Pool::new(opts).unwrap();
             let mut conn = pool.get_conn().unwrap();
 
-            missing::migrations::runner().run(&mut conn).unwrap();
+            missing::migrations::runner(&mut conn).run().unwrap();
 
             let migration1 = Migration::unapplied(
                 "V1__initial",
@@ -591,14 +591,14 @@ mod mysql {
                 .set_db_port("3306");
 
             let migrations = get_migrations();
-            let runner = Runner::new(&migrations)
+            let mut runner = Runner::new(&migrations, &mut config)
                 .set_grouped(false)
                 .set_abort_divergent(true)
                 .set_abort_missing(true);
 
-            runner.run(&mut config).unwrap();
+            runner.run().unwrap();
 
-            let applied_migrations = runner.get_applied_migrations(&mut config).unwrap();
+            let applied_migrations = runner.get_applied_migrations().unwrap();
             assert_eq!(5, applied_migrations.len());
 
             assert_eq!(migrations[0].version(), applied_migrations[0].version());
@@ -632,12 +632,12 @@ mod mysql {
                 .set_db_port("3306");
 
             let migrations = get_migrations();
-            let runner = Runner::new(&migrations)
+            let mut runner = Runner::new(&migrations, &mut config)
                 .set_grouped(false)
                 .set_abort_divergent(true)
                 .set_abort_missing(true);
 
-            let report = runner.run(&mut config).unwrap();
+            let report = runner.run().unwrap();
 
             let applied_migrations = report.applied_migrations();
             assert_eq!(5, applied_migrations.len());
@@ -673,17 +673,14 @@ mod mysql {
                 .set_db_port("3306");
 
             let migrations = get_migrations();
-            let runner = Runner::new(&migrations)
+            let mut runner = Runner::new(&migrations, &mut config)
                 .set_grouped(false)
                 .set_abort_divergent(true)
                 .set_abort_missing(true);
 
-            runner.run(&mut config).unwrap();
+            runner.run().unwrap();
 
-            let applied_migration = runner
-                .get_last_applied_migration(&mut config)
-                .unwrap()
-                .unwrap();
+            let applied_migration = runner.get_last_applied_migration().unwrap().unwrap();
             assert_eq!(5, applied_migration.version());
 
             assert_eq!(migrations[4].version(), applied_migration.version());
@@ -700,9 +697,9 @@ mod mysql {
             let pool = mysql::Pool::new(opts).unwrap();
             let mut conn = pool.get_conn().unwrap();
 
-            let report = embedded::migrations::runner()
+            let report = embedded::migrations::runner(&mut conn)
                 .set_target(Target::Fake)
-                .run(&mut conn)
+                .run()
                 .unwrap();
 
             let applied_migrations = report.applied_migrations();
@@ -735,9 +732,9 @@ mod mysql {
             let pool = mysql::Pool::new(opts).unwrap();
             let mut conn = pool.get_conn().unwrap();
 
-            let report = embedded::migrations::runner()
+            let report = embedded::migrations::runner(&mut conn)
                 .set_target(Target::FakeVersion(2))
-                .run(&mut conn)
+                .run()
                 .unwrap();
 
             let applied_migrations = report.applied_migrations();

--- a/refinery/tests/mysql_async.rs
+++ b/refinery/tests/mysql_async.rs
@@ -89,8 +89,8 @@ mod mysql_async {
                 mysql_async::Pool::new("mysql://refinery:root@localhost:3306/refinery_test");
             let mut conn = pool.get_conn().await.unwrap();
 
-            embedded::migrations::runner()
-                .run_async(&mut pool)
+            embedded::migrations::runner(&mut pool)
+                .run_async()
                 .await
                 .unwrap();
 
@@ -115,9 +115,9 @@ mod mysql_async {
                 mysql_async::Pool::new("mysql://refinery:root@localhost:3306/refinery_test");
             let mut conn = pool.get_conn().await.unwrap();
 
-            embedded::migrations::runner()
+            embedded::migrations::runner(&mut pool)
                 .set_grouped(true)
-                .run_async(&mut pool)
+                .run_async()
                 .await
                 .unwrap();
 
@@ -142,8 +142,8 @@ mod mysql_async {
             let mut pool =
                 mysql_async::Pool::new("mysql://refinery:root@localhost:3306/refinery_test");
 
-            let report = embedded::migrations::runner()
-                .run_async(&mut pool)
+            let report = embedded::migrations::runner(&mut pool)
+                .run_async()
                 .await
                 .unwrap();
 
@@ -177,8 +177,8 @@ mod mysql_async {
                 mysql_async::Pool::new("mysql://refinery:root@localhost:3306/refinery_test");
             let mut conn = pool.get_conn().await.unwrap();
 
-            embedded::migrations::runner()
-                .run_async(&mut pool)
+            embedded::migrations::runner(&mut pool)
+                .run_async()
                 .await
                 .unwrap();
 
@@ -205,9 +205,9 @@ mod mysql_async {
                 mysql_async::Pool::new("mysql://refinery:root@localhost:3306/refinery_test");
             let mut conn = pool.get_conn().await.unwrap();
 
-            embedded::migrations::runner()
+            embedded::migrations::runner(&mut pool)
                 .set_grouped(true)
-                .run_async(&mut pool)
+                .run_async()
                 .await
                 .unwrap();
 
@@ -233,8 +233,8 @@ mod mysql_async {
             let mut pool =
                 mysql_async::Pool::new("mysql://refinery:root@localhost:3306/refinery_test");
 
-            embedded::migrations::runner()
-                .run_async(&mut pool)
+            embedded::migrations::runner(&mut pool)
+                .run_async()
                 .await
                 .unwrap();
 
@@ -259,9 +259,9 @@ mod mysql_async {
             let mut pool =
                 mysql_async::Pool::new("mysql://refinery:root@localhost:3306/refinery_test");
 
-            embedded::migrations::runner()
+            embedded::migrations::runner(&mut pool)
                 .set_grouped(true)
-                .run_async(&mut pool)
+                .run_async()
                 .await
                 .unwrap();
 
@@ -286,7 +286,7 @@ mod mysql_async {
             let mut pool =
                 mysql_async::Pool::new("mysql://refinery:root@localhost:3306/refinery_test");
 
-            let result = broken::migrations::runner().run_async(&mut pool).await;
+            let result = broken::migrations::runner(&mut pool).run_async().await;
 
             let current = pool
                 .get_last_applied_migration(DEFAULT_TABLE_NAME)
@@ -323,8 +323,8 @@ mod mysql_async {
             let mut pool =
                 mysql_async::Pool::new("mysql://refinery:root@localhost:3306/refinery_test");
 
-            embedded::migrations::runner()
-                .run_async(&mut pool)
+            embedded::migrations::runner(&mut pool)
+                .run_async()
                 .await
                 .unwrap();
 
@@ -359,8 +359,8 @@ mod mysql_async {
             let mut pool =
                 mysql_async::Pool::new("mysql://refinery:root@localhost:3306/refinery_test");
 
-            embedded::migrations::runner()
-                .run_async(&mut pool)
+            embedded::migrations::runner(&mut pool)
+                .run_async()
                 .await
                 .unwrap();
 
@@ -396,10 +396,10 @@ mod mysql_async {
             let mut pool =
                 mysql_async::Pool::new("mysql://refinery:root@localhost:3306/refinery_test");
 
-            let report = embedded::migrations::runner()
+            let report = embedded::migrations::runner(&mut pool)
                 .set_grouped(true)
                 .set_target(Target::Version(3))
-                .run_async(&mut pool)
+                .run_async()
                 .await
                 .unwrap();
 
@@ -436,9 +436,9 @@ mod mysql_async {
             let mut pool =
                 mysql_async::Pool::new("mysql://refinery:root@localhost:3306/refinery_test");
 
-            let report = embedded::migrations::runner()
+            let report = embedded::migrations::runner(&mut pool)
                 .set_target(Target::Version(3))
-                .run_async(&mut pool)
+                .run_async()
                 .await
                 .unwrap();
 
@@ -475,8 +475,8 @@ mod mysql_async {
             let mut pool =
                 mysql_async::Pool::new("mysql://refinery:root@localhost:3306/refinery_test");
 
-            embedded::migrations::runner()
-                .run_async(&mut pool)
+            embedded::migrations::runner(&mut pool)
+                .run_async()
                 .await
                 .unwrap();
 
@@ -515,13 +515,13 @@ mod mysql_async {
             let mut pool =
                 mysql_async::Pool::new("mysql://refinery:root@localhost:3306/refinery_test");
 
-            embedded::migrations::runner()
-                .run_async(&mut pool)
+            embedded::migrations::runner(&mut pool)
+                .run_async()
                 .await
                 .unwrap();
 
-            embedded::migrations::runner()
-                .run_async(&mut pool)
+            embedded::migrations::runner(&mut pool)
+                .run_async()
                 .await
                 .unwrap();
 
@@ -561,8 +561,8 @@ mod mysql_async {
             let mut pool =
                 mysql_async::Pool::new("mysql://refinery:root@localhost:3306/refinery_test");
 
-            missing::migrations::runner()
-                .run_async(&mut pool)
+            missing::migrations::runner(&mut pool)
+                .run_async()
                 .await
                 .unwrap();
 
@@ -617,17 +617,14 @@ mod mysql_async {
                 .set_db_port("3306");
 
             let migrations = get_migrations();
-            let runner = Runner::new(&migrations)
+            let mut runner = Runner::new(&migrations, &mut config)
                 .set_grouped(false)
                 .set_abort_divergent(true)
                 .set_abort_missing(true);
 
-            runner.run_async(&mut config).await.unwrap();
+            runner.run_async().await.unwrap();
 
-            let applied_migrations = runner
-                .get_applied_migrations_async(&mut config)
-                .await
-                .unwrap();
+            let applied_migrations = runner.get_applied_migrations_async().await.unwrap();
             assert_eq!(5, applied_migrations.len());
 
             assert_eq!(migrations[0].version(), applied_migrations[0].version());
@@ -662,12 +659,12 @@ mod mysql_async {
                 .set_db_port("3306");
 
             let migrations = get_migrations();
-            let runner = Runner::new(&migrations)
+            let mut runner = Runner::new(&migrations, &mut config)
                 .set_grouped(false)
                 .set_abort_divergent(true)
                 .set_abort_missing(true);
 
-            let report = runner.run_async(&mut config).await.unwrap();
+            let report = runner.run_async().await.unwrap();
 
             let applied_migrations = report.applied_migrations();
             assert_eq!(5, applied_migrations.len());
@@ -704,15 +701,15 @@ mod mysql_async {
                 .set_db_port("3306");
 
             let migrations = get_migrations();
-            let runner = Runner::new(&migrations)
+            let mut runner = Runner::new(&migrations, &mut config)
                 .set_grouped(false)
                 .set_abort_divergent(true)
                 .set_abort_missing(true);
 
-            runner.run_async(&mut config).await.unwrap();
+            runner.run_async().await.unwrap();
 
             let applied_migration = runner
-                .get_last_applied_migration_async(&mut config)
+                .get_last_applied_migration_async()
                 .await
                 .unwrap()
                 .unwrap();
@@ -732,9 +729,9 @@ mod mysql_async {
                 mysql_async::Pool::new("mysql://refinery:root@localhost:3306/refinery_test");
             let mut conn = pool.get_conn().await.unwrap();
 
-            let report = embedded::migrations::runner()
+            let report = embedded::migrations::runner(&mut pool)
                 .set_target(Target::Fake)
-                .run_async(&mut pool)
+                .run_async()
                 .await
                 .unwrap();
 
@@ -771,9 +768,9 @@ mod mysql_async {
                 mysql_async::Pool::new("mysql://refinery:root@localhost:3306/refinery_test");
             let mut conn = pool.get_conn().await.unwrap();
 
-            let report = embedded::migrations::runner()
+            let report = embedded::migrations::runner(&mut pool)
                 .set_target(Target::FakeVersion(2))
-                .run_async(&mut pool)
+                .run_async()
                 .await
                 .unwrap();
 

--- a/refinery/tests/postgres.rs
+++ b/refinery/tests/postgres.rs
@@ -95,7 +95,7 @@ mod postgres {
             let mut client =
                 Client::connect("postgres://postgres@localhost:5432/postgres", NoTls).unwrap();
 
-            let report = embedded::migrations::runner().run(&mut client).unwrap();
+            let report = embedded::migrations::runner(&mut client).run().unwrap();
 
             let migrations = get_migrations();
             let applied_migrations = report.applied_migrations();
@@ -124,7 +124,7 @@ mod postgres {
         run_test(|| {
             let mut client =
                 Client::connect("postgres://postgres@localhost:5432/postgres", NoTls).unwrap();
-            embedded::migrations::runner().run(&mut client).unwrap();
+            embedded::migrations::runner(&mut client).run().unwrap();
             for row in &client
                 .query(
                     &format!(
@@ -147,9 +147,9 @@ mod postgres {
             let mut client =
                 Client::connect("postgres://postgres@localhost:5432/postgres", NoTls).unwrap();
 
-            embedded::migrations::runner()
+            embedded::migrations::runner(&mut client)
                 .set_grouped(true)
-                .run(&mut client)
+                .run()
                 .unwrap();
 
             for row in &client
@@ -173,7 +173,7 @@ mod postgres {
         run_test(|| {
             let mut client =
                 Client::connect("postgres://postgres@localhost:5432/postgres", NoTls).unwrap();
-            embedded::migrations::runner().run(&mut client).unwrap();
+            embedded::migrations::runner(&mut client).run().unwrap();
             client
                 .execute(
                     "INSERT INTO persons (name, city) VALUES ($1, $2)",
@@ -195,9 +195,9 @@ mod postgres {
             let mut client =
                 Client::connect("postgres://postgres@localhost:5432/postgres", NoTls).unwrap();
 
-            embedded::migrations::runner()
+            embedded::migrations::runner(&mut client)
                 .set_grouped(false)
-                .run(&mut client)
+                .run()
                 .unwrap();
 
             client
@@ -221,7 +221,7 @@ mod postgres {
             let mut client =
                 Client::connect("postgres://postgres@localhost:5432/postgres", NoTls).unwrap();
 
-            embedded::migrations::runner().run(&mut client).unwrap();
+            embedded::migrations::runner(&mut client).run().unwrap();
 
             let current = client
                 .get_last_applied_migration(DEFAULT_TABLE_NAME)
@@ -242,9 +242,9 @@ mod postgres {
             let mut client =
                 Client::connect("postgres://postgres@localhost:5432/postgres", NoTls).unwrap();
 
-            embedded::migrations::runner()
+            embedded::migrations::runner(&mut client)
                 .set_grouped(false)
-                .run(&mut client)
+                .run()
                 .unwrap();
 
             let current = client
@@ -265,7 +265,7 @@ mod postgres {
             let mut client =
                 Client::connect("postgres://postgres@localhost:5432/postgres", NoTls).unwrap();
 
-            let result = broken::migrations::runner().run(&mut client);
+            let result = broken::migrations::runner(&mut client).run();
 
             assert!(result.is_err());
             println!("CURRENT: {:?}", result);
@@ -303,9 +303,9 @@ mod postgres {
             let mut client =
                 Client::connect("postgres://postgres@localhost:5432/postgres", NoTls).unwrap();
 
-            let result = broken::migrations::runner()
+            let result = broken::migrations::runner(&mut client)
                 .set_grouped(true)
-                .run(&mut client);
+                .run();
 
             assert!(result.is_err());
             println!("CURRENT: {:?}", result);
@@ -323,7 +323,7 @@ mod postgres {
             let mut client =
                 Client::connect("postgres://postgres@localhost:5432/postgres", NoTls).unwrap();
 
-            embedded::migrations::runner().run(&mut client).unwrap();
+            embedded::migrations::runner(&mut client).run().unwrap();
 
             let migrations = get_migrations();
             let applied_migrations = client.get_applied_migrations(DEFAULT_TABLE_NAME).unwrap();
@@ -352,7 +352,7 @@ mod postgres {
             let mut client =
                 Client::connect("postgres://postgres@localhost:5432/postgres", NoTls).unwrap();
 
-            embedded::migrations::runner().run(&mut client).unwrap();
+            embedded::migrations::runner(&mut client).run().unwrap();
 
             let migrations = get_migrations();
 
@@ -384,9 +384,9 @@ mod postgres {
             let mut client =
                 Client::connect("postgres://postgres@localhost:5432/postgres", NoTls).unwrap();
 
-            let report = embedded::migrations::runner()
+            let report = embedded::migrations::runner(&mut client)
                 .set_target(Target::Version(3))
-                .run(&mut client)
+                .run()
                 .unwrap();
 
             let current = client
@@ -420,10 +420,10 @@ mod postgres {
             let mut client =
                 Client::connect("postgres://postgres@localhost:5432/postgres", NoTls).unwrap();
 
-            let report = embedded::migrations::runner()
+            let report = embedded::migrations::runner(&mut client)
                 .set_target(Target::Version(3))
                 .set_grouped(true)
-                .run(&mut client)
+                .run()
                 .unwrap();
 
             let current = client
@@ -457,7 +457,7 @@ mod postgres {
             let mut client =
                 Client::connect("postgres://postgres@localhost:5432/postgres", NoTls).unwrap();
 
-            embedded::migrations::runner().run(&mut client).unwrap();
+            embedded::migrations::runner(&mut client).run().unwrap();
 
             let migration = Migration::unapplied(
                 "V4__add_year_field_to_cars",
@@ -491,7 +491,7 @@ mod postgres {
             let mut client =
                 Client::connect("postgres://postgres@localhost:5432/postgres", NoTls).unwrap();
 
-            embedded::migrations::runner().run(&mut client).unwrap();
+            embedded::migrations::runner(&mut client).run().unwrap();
 
             let migration = Migration::unapplied(
                 "V2__add_year_field_to_cars",
@@ -526,7 +526,7 @@ mod postgres {
             let mut client =
                 Client::connect("postgres://postgres@localhost:5432/postgres", NoTls).unwrap();
 
-            missing::migrations::runner().run(&mut client).unwrap();
+            missing::migrations::runner(&mut client).run().unwrap();
 
             let migration1 = Migration::unapplied(
                 "V1__initial",
@@ -575,14 +575,14 @@ mod postgres {
                 .set_db_port("5432");
 
             let migrations = get_migrations();
-            let runner = Runner::new(&migrations)
+            let mut runner = Runner::new(&migrations, &mut config)
                 .set_grouped(false)
                 .set_abort_divergent(true)
                 .set_abort_missing(true);
 
-            runner.run(&mut config).unwrap();
+            runner.run().unwrap();
 
-            let applied_migrations = runner.get_applied_migrations(&mut config).unwrap();
+            let applied_migrations = runner.get_applied_migrations().unwrap();
             assert_eq!(5, applied_migrations.len());
 
             assert_eq!(migrations[0].version(), applied_migrations[0].version());
@@ -615,12 +615,12 @@ mod postgres {
                 .set_db_port("5432");
 
             let migrations = get_migrations();
-            let runner = Runner::new(&migrations)
+            let mut runner = Runner::new(&migrations, &mut config)
                 .set_grouped(false)
                 .set_abort_divergent(true)
                 .set_abort_missing(true);
 
-            let report = runner.run(&mut config).unwrap();
+            let report = runner.run().unwrap();
 
             let applied_migrations = report.applied_migrations();
             assert_eq!(5, applied_migrations.len());
@@ -655,17 +655,14 @@ mod postgres {
                 .set_db_port("5432");
 
             let migrations = get_migrations();
-            let runner = Runner::new(&migrations)
+            let mut runner = Runner::new(&migrations, &mut config)
                 .set_grouped(false)
                 .set_abort_divergent(true)
                 .set_abort_missing(true);
 
-            runner.run(&mut config).unwrap();
+            runner.run().unwrap();
 
-            let applied_migration = runner
-                .get_last_applied_migration(&mut config)
-                .unwrap()
-                .unwrap();
+            let applied_migration = runner.get_last_applied_migration().unwrap().unwrap();
             assert_eq!(5, applied_migration.version());
 
             assert_eq!(migrations[4].version(), applied_migration.version());
@@ -680,9 +677,9 @@ mod postgres {
             let mut client =
                 Client::connect("postgres://postgres@localhost:5432/postgres", NoTls).unwrap();
 
-            let report = embedded::migrations::runner()
+            let report = embedded::migrations::runner(&mut client)
                 .set_target(Target::Fake)
-                .run(&mut client)
+                .run()
                 .unwrap();
 
             let applied_migrations = report.applied_migrations();
@@ -715,9 +712,9 @@ mod postgres {
             let mut client =
                 Client::connect("postgres://postgres@localhost:5432/postgres", NoTls).unwrap();
 
-            let report = embedded::migrations::runner()
+            let report = embedded::migrations::runner(&mut client)
                 .set_target(Target::FakeVersion(2))
-                .run(&mut client)
+                .run()
                 .unwrap();
 
             let applied_migrations = report.applied_migrations();

--- a/refinery/tests/tiberius.rs
+++ b/refinery/tests/tiberius.rs
@@ -120,8 +120,8 @@ mod tiberius {
                 .await
                 .unwrap();
 
-            embedded::migrations::runner()
-                .run_async(&mut client)
+            embedded::migrations::runner(&mut client)
+                .run_async()
                 .await
                 .unwrap();
 
@@ -171,8 +171,8 @@ mod tiberius {
                 .await
                 .unwrap();
 
-            embedded::migrations::runner()
-                .run_async(&mut client)
+            embedded::migrations::runner(&mut client)
+                .run_async()
                 .await
                 .unwrap();
 
@@ -223,8 +223,8 @@ mod tiberius {
                 .await
                 .unwrap();
 
-            missing::migrations::runner()
-                .run_async(&mut client)
+            missing::migrations::runner(&mut client)
+                .run_async()
                 .await
                 .unwrap();
 
@@ -285,8 +285,8 @@ mod tiberius {
                 .await
                 .unwrap();
 
-            embedded::migrations::runner()
-                .run_async(&mut client)
+            embedded::migrations::runner(&mut client)
+                .run_async()
                 .await
                 .unwrap();
 
@@ -326,9 +326,9 @@ mod tiberius {
                 .await
                 .unwrap();
 
-            embedded::migrations::runner()
+            embedded::migrations::runner(&mut client)
                 .set_grouped(true)
-                .run_async(&mut client)
+                .run_async()
                 .await
                 .unwrap();
 
@@ -368,8 +368,8 @@ mod tiberius {
                 .await
                 .unwrap();
 
-            let report = embedded::migrations::runner()
-                .run_async(&mut client)
+            let report = embedded::migrations::runner(&mut client)
+                .run_async()
                 .await
                 .unwrap();
 
@@ -414,8 +414,8 @@ mod tiberius {
                 .await
                 .unwrap();
 
-            embedded::migrations::runner()
-                .run_async(&mut client)
+            embedded::migrations::runner(&mut client)
+                .run_async()
                 .await
                 .unwrap();
 
@@ -460,9 +460,9 @@ mod tiberius {
                 .await
                 .unwrap();
 
-            embedded::migrations::runner()
+            embedded::migrations::runner(&mut client)
                 .set_grouped(true)
-                .run_async(&mut client)
+                .run_async()
                 .await
                 .unwrap();
 
@@ -507,8 +507,8 @@ mod tiberius {
                 .await
                 .unwrap();
 
-            embedded::migrations::runner()
-                .run_async(&mut client)
+            embedded::migrations::runner(&mut client)
+                .run_async()
                 .await
                 .unwrap();
 
@@ -556,8 +556,8 @@ mod tiberius {
                 .await
                 .unwrap();
 
-            embedded::migrations::runner()
-                .run_async(&mut client)
+            embedded::migrations::runner(&mut client)
+                .run_async()
                 .await
                 .unwrap();
 
@@ -593,9 +593,9 @@ mod tiberius {
                 .await
                 .unwrap();
 
-            embedded::migrations::runner()
+            embedded::migrations::runner(&mut client)
                 .set_grouped(true)
-                .run_async(&mut client)
+                .run_async()
                 .await
                 .unwrap();
 
@@ -631,7 +631,7 @@ mod tiberius {
                 .await
                 .unwrap();
 
-            let result = broken::migrations::runner().run_async(&mut client).await;
+            let result = broken::migrations::runner(&mut client).run_async().await;
 
             let current = client
                 .get_last_applied_migration(DEFAULT_TABLE_NAME)
@@ -680,9 +680,9 @@ mod tiberius {
                 .await
                 .unwrap();
 
-            let result = broken::migrations::runner()
+            let result = broken::migrations::runner(&mut client)
                 .set_grouped(true)
-                .run_async(&mut client)
+                .run_async()
                 .await;
 
             let current = client
@@ -726,8 +726,8 @@ mod tiberius {
                 .await
                 .unwrap();
 
-            embedded::migrations::runner()
-                .run_async(&mut client)
+            embedded::migrations::runner(&mut client)
+                .run_async()
                 .await
                 .unwrap();
 
@@ -762,17 +762,14 @@ mod tiberius {
             let mut config = Config::from_str(CONFIG).unwrap();
 
             let migrations = get_migrations();
-            let runner = Runner::new(&migrations)
+            let mut runner = Runner::new(&migrations, &mut config)
                 .set_grouped(false)
                 .set_abort_divergent(true)
                 .set_abort_missing(true);
 
-            runner.run_async(&mut config).await.unwrap();
+            runner.run_async().await.unwrap();
 
-            let applied_migrations = runner
-                .get_applied_migrations_async(&mut config)
-                .await
-                .unwrap();
+            let applied_migrations = runner.get_applied_migrations_async().await.unwrap();
             assert_eq!(5, applied_migrations.len());
 
             assert_eq!(migrations[0].version(), applied_migrations[0].version());
@@ -802,12 +799,12 @@ mod tiberius {
             let mut config = Config::from_str(CONFIG).unwrap();
 
             let migrations = get_migrations();
-            let runner = Runner::new(&migrations)
+            let mut runner = Runner::new(&migrations, &mut config)
                 .set_grouped(false)
                 .set_abort_divergent(true)
                 .set_abort_missing(true);
 
-            let report = runner.run_async(&mut config).await.unwrap();
+            let report = runner.run_async().await.unwrap();
 
             let applied_migrations = report.applied_migrations();
             assert_eq!(5, applied_migrations.len());
@@ -839,15 +836,15 @@ mod tiberius {
             let mut config = Config::from_str(CONFIG).unwrap();
 
             let migrations = get_migrations();
-            let runner = Runner::new(&migrations)
+            let mut runner = Runner::new(&migrations, &mut config)
                 .set_grouped(false)
                 .set_abort_divergent(true)
                 .set_abort_missing(true);
 
-            runner.run_async(&mut config).await.unwrap();
+            runner.run_async().await.unwrap();
 
             let applied_migration = runner
-                .get_last_applied_migration_async(&mut config)
+                .get_last_applied_migration_async()
                 .await
                 .unwrap()
                 .unwrap();
@@ -878,9 +875,9 @@ mod tiberius {
                 .await
                 .unwrap();
 
-            let report = embedded::migrations::runner()
+            let report = embedded::migrations::runner(&mut client)
                 .set_target(Target::Version(3))
-                .run_async(&mut client)
+                .run_async()
                 .await
                 .unwrap();
 
@@ -929,10 +926,10 @@ mod tiberius {
                 .await
                 .unwrap();
 
-            let report = embedded::migrations::runner()
+            let report = embedded::migrations::runner(&mut client)
                 .set_target(Target::Version(3))
                 .set_grouped(true)
-                .run_async(&mut client)
+                .run_async()
                 .await
                 .unwrap();
 
@@ -981,9 +978,9 @@ mod tiberius {
                 .await
                 .unwrap();
 
-            let report = embedded::migrations::runner()
+            let report = embedded::migrations::runner(&mut client)
                 .set_target(Target::Fake)
-                .run_async(&mut client)
+                .run_async()
                 .await
                 .unwrap();
 
@@ -1035,9 +1032,9 @@ mod tiberius {
                 .await
                 .unwrap();
 
-            let report = embedded::migrations::runner()
+            let report = embedded::migrations::runner(&mut client)
                 .set_target(Target::FakeVersion(2))
-                .run_async(&mut client)
+                .run_async()
                 .await
                 .unwrap();
 

--- a/refinery/tests/tokio_postgres.rs
+++ b/refinery/tests/tokio_postgres.rs
@@ -107,8 +107,8 @@ mod tokio_postgres {
                 connection.await.unwrap();
             });
 
-            let report = embedded::migrations::runner()
-                .run_async(&mut client)
+            let report = embedded::migrations::runner(&mut client)
+                .run_async()
                 .await
                 .unwrap();
 
@@ -147,8 +147,8 @@ mod tokio_postgres {
                 connection.await.unwrap();
             });
 
-            embedded::migrations::runner()
-                .run_async(&mut client)
+            embedded::migrations::runner(&mut client)
+                .run_async()
                 .await
                 .unwrap();
 
@@ -183,9 +183,9 @@ mod tokio_postgres {
                 connection.await.unwrap();
             });
 
-            embedded::migrations::runner()
+            embedded::migrations::runner(&mut client)
                 .set_grouped(true)
-                .run_async(&mut client)
+                .run_async()
                 .await
                 .unwrap();
 
@@ -220,8 +220,8 @@ mod tokio_postgres {
                 connection.await.unwrap();
             });
 
-            embedded::migrations::runner()
-                .run_async(&mut client)
+            embedded::migrations::runner(&mut client)
+                .run_async()
                 .await
                 .unwrap();
 
@@ -259,9 +259,9 @@ mod tokio_postgres {
                 connection.await.unwrap();
             });
 
-            embedded::migrations::runner()
+            embedded::migrations::runner(&mut client)
                 .set_grouped(true)
-                .run_async(&mut client)
+                .run_async()
                 .await
                 .unwrap();
 
@@ -299,8 +299,8 @@ mod tokio_postgres {
                 connection.await.unwrap();
             });
 
-            embedded::migrations::runner()
-                .run_async(&mut client)
+            embedded::migrations::runner(&mut client)
+                .run_async()
                 .await
                 .unwrap();
 
@@ -331,9 +331,9 @@ mod tokio_postgres {
                 connection.await.unwrap();
             });
 
-            embedded::migrations::runner()
+            embedded::migrations::runner(&mut client)
                 .set_grouped(true)
-                .run_async(&mut client)
+                .run_async()
                 .await
                 .unwrap();
 
@@ -364,7 +364,7 @@ mod tokio_postgres {
                 connection.await.unwrap();
             });
 
-            let result = broken::migrations::runner().run_async(&mut client).await;
+            let result = broken::migrations::runner(&mut client).run_async().await;
 
             assert!(result.is_err());
 
@@ -408,9 +408,9 @@ mod tokio_postgres {
                 connection.await.unwrap();
             });
 
-            let result = broken::migrations::runner()
+            let result = broken::migrations::runner(&mut client)
                 .set_grouped(true)
-                .run_async(&mut client)
+                .run_async()
                 .await;
 
             assert!(result.is_err());
@@ -437,8 +437,8 @@ mod tokio_postgres {
                 connection.await.unwrap();
             });
 
-            embedded::migrations::runner()
-                .run_async(&mut client)
+            embedded::migrations::runner(&mut client)
+                .run_async()
                 .await
                 .unwrap();
 
@@ -479,8 +479,8 @@ mod tokio_postgres {
                 connection.await.unwrap();
             });
 
-            embedded::migrations::runner()
-                .run_async(&mut client)
+            embedded::migrations::runner(&mut client)
+                .run_async()
                 .await
                 .unwrap();
 
@@ -522,9 +522,9 @@ mod tokio_postgres {
                 connection.await.unwrap();
             });
 
-            let report = embedded::migrations::runner()
+            let report = embedded::migrations::runner(&mut client)
                 .set_target(Target::Version(3))
-                .run_async(&mut client)
+                .run_async()
                 .await
                 .unwrap();
 
@@ -567,10 +567,10 @@ mod tokio_postgres {
                 connection.await.unwrap();
             });
 
-            let report = embedded::migrations::runner()
+            let report = embedded::migrations::runner(&mut client)
                 .set_target(Target::Version(3))
                 .set_grouped(true)
-                .run_async(&mut client)
+                .run_async()
                 .await
                 .unwrap();
 
@@ -613,8 +613,8 @@ mod tokio_postgres {
                 connection.await.unwrap();
             });
 
-            embedded::migrations::runner()
-                .run_async(&mut client)
+            embedded::migrations::runner(&mut client)
+                .run_async()
                 .await
                 .unwrap();
 
@@ -658,8 +658,8 @@ mod tokio_postgres {
                 connection.await.unwrap();
             });
 
-            embedded::migrations::runner()
-                .run_async(&mut client)
+            embedded::migrations::runner(&mut client)
+                .run_async()
                 .await
                 .unwrap();
 
@@ -705,8 +705,8 @@ mod tokio_postgres {
                 connection.await.unwrap();
             });
 
-            missing::migrations::runner()
-                .run_async(&mut client)
+            missing::migrations::runner(&mut client)
+                .run_async()
                 .await
                 .unwrap();
 
@@ -760,17 +760,14 @@ mod tokio_postgres {
                 .set_db_port("5432");
 
             let migrations = get_migrations();
-            let runner = Runner::new(&migrations)
+            let mut runner = Runner::new(&migrations, &mut config)
                 .set_grouped(false)
                 .set_abort_divergent(true)
                 .set_abort_missing(true);
 
-            runner.run_async(&mut config).await.unwrap();
+            runner.run_async().await.unwrap();
 
-            let applied_migrations = runner
-                .get_applied_migrations_async(&mut config)
-                .await
-                .unwrap();
+            let applied_migrations = runner.get_applied_migrations_async().await.unwrap();
             assert_eq!(5, applied_migrations.len());
 
             assert_eq!(migrations[0].version(), applied_migrations[0].version());
@@ -804,12 +801,12 @@ mod tokio_postgres {
                 .set_db_port("5432");
 
             let migrations = get_migrations();
-            let runner = Runner::new(&migrations)
+            let mut runner = Runner::new(&migrations, &mut config)
                 .set_grouped(false)
                 .set_abort_divergent(true)
                 .set_abort_missing(true);
 
-            let report = runner.run_async(&mut config).await.unwrap();
+            let report = runner.run_async().await.unwrap();
 
             let applied_migrations = report.applied_migrations();
             assert_eq!(5, applied_migrations.len());
@@ -845,15 +842,15 @@ mod tokio_postgres {
                 .set_db_port("5432");
 
             let migrations = get_migrations();
-            let runner = Runner::new(&migrations)
+            let mut runner = Runner::new(&migrations, &mut config)
                 .set_grouped(false)
                 .set_abort_divergent(true)
                 .set_abort_missing(true);
 
-            runner.run_async(&mut config).await.unwrap();
+            runner.run_async().await.unwrap();
 
             let applied_migration = runner
-                .get_last_applied_migration_async(&mut config)
+                .get_last_applied_migration_async()
                 .await
                 .unwrap()
                 .unwrap();
@@ -878,9 +875,9 @@ mod tokio_postgres {
                 connection.await.unwrap();
             });
 
-            let report = embedded::migrations::runner()
+            let report = embedded::migrations::runner(&mut client)
                 .set_target(Target::Fake)
-                .run_async(&mut client)
+                .run_async()
                 .await
                 .unwrap();
 
@@ -922,9 +919,9 @@ mod tokio_postgres {
                 connection.await.unwrap();
             });
 
-            let report = embedded::migrations::runner()
+            let report = embedded::migrations::runner(&mut client)
                 .set_target(Target::FakeVersion(2))
-                .run_async(&mut client)
+                .run_async()
                 .await
                 .unwrap();
 

--- a/refinery_cli/src/migrate.rs
+++ b/refinery_cli/src/migrate.rs
@@ -72,13 +72,13 @@ fn run_migrations(
                         .context("Can't start tokio runtime")?;
 
                     runtime.block_on(async {
-                        Runner::new(&migrations)
+                        Runner::new(&migrations, &mut config)
                             .set_grouped(grouped)
                             .set_target(target)
                             .set_abort_divergent(divergent)
                             .set_abort_missing(missing)
                             .set_migration_table_name(table_name)
-                            .run_async(&mut config)
+                            .run_async()
                             .await
                     })?;
                 } else {
@@ -89,13 +89,13 @@ fn run_migrations(
         _db_type @ (ConfigDbType::Mysql | ConfigDbType::Postgres | ConfigDbType::Sqlite) => {
             cfg_if::cfg_if! {
                 if #[cfg(any(feature = "mysql", feature = "postgresql", feature = "sqlite"))] {
-                    Runner::new(&migrations)
+                    Runner::new(&migrations, &mut config)
                         .set_grouped(grouped)
                         .set_abort_divergent(divergent)
                         .set_abort_missing(missing)
                         .set_target(target)
                         .set_migration_table_name(table_name)
-                        .run(&mut config)?;
+                        .run()?;
                 } else {
                     panic!("tried to migrate async from config for a {:?} database, but it's matching feature was not enabled!", _db_type);
                 }

--- a/refinery_core/src/runner.rs
+++ b/refinery_core/src/runner.rs
@@ -312,38 +312,35 @@ impl<'a, C> Runner<'a, C> {
     }
 
     /// Queries the database for the last applied migration, returns None if there aren't applied Migrations
-    pub fn get_last_applied_migration(&self, conn: &'_ mut C) -> Result<Option<Migration>, Error>
+    pub fn get_last_applied_migration(&mut self) -> Result<Option<Migration>, Error>
     where
         C: Migrate,
     {
-        Migrate::get_last_applied_migration(conn, &self.migration_table_name)
+        Migrate::get_last_applied_migration(self.connection, &self.migration_table_name)
     }
 
     /// Queries the database asynchronously for the last applied migration, returns None if there aren't applied Migrations
-    pub async fn get_last_applied_migration_async(
-        &self,
-        conn: &mut C,
-    ) -> Result<Option<Migration>, Error>
+    pub async fn get_last_applied_migration_async(&mut self) -> Result<Option<Migration>, Error>
     where
         C: AsyncMigrate + Send,
     {
-        AsyncMigrate::get_last_applied_migration(conn, &self.migration_table_name).await
+        AsyncMigrate::get_last_applied_migration(self.connection, &self.migration_table_name).await
     }
 
     /// Queries the database for all previous applied migrations
-    pub fn get_applied_migrations(&self, conn: &'_ mut C) -> Result<Vec<Migration>, Error>
+    pub fn get_applied_migrations(&mut self) -> Result<Vec<Migration>, Error>
     where
         C: Migrate,
     {
-        Migrate::get_applied_migrations(conn, &self.migration_table_name)
+        Migrate::get_applied_migrations(self.connection, &self.migration_table_name)
     }
 
     /// Queries the database asynchronously for all previous applied migrations
-    pub async fn get_applied_migrations_async(&self, conn: &mut C) -> Result<Vec<Migration>, Error>
+    pub async fn get_applied_migrations_async(&mut self) -> Result<Vec<Migration>, Error>
     where
         C: AsyncMigrate + Send,
     {
-        AsyncMigrate::get_applied_migrations(conn, &self.migration_table_name).await
+        AsyncMigrate::get_applied_migrations(self.connection, &self.migration_table_name).await
     }
 
     /// Set the table name to use for the migrations table. The default name is `refinery_schema_history`
@@ -378,7 +375,7 @@ impl<'a, C> Runner<'a, C> {
     }
 
     /// Runs the Migrations in the supplied database connection
-    pub fn run(&'a mut self) -> Result<Report, Error>
+    pub fn run(&mut self) -> Result<Report, Error>
     where
         C: Migrate,
     {
@@ -394,7 +391,7 @@ impl<'a, C> Runner<'a, C> {
     }
 
     /// Runs the Migrations asynchronously in the supplied database connection
-    pub async fn run_async(&'a mut self) -> Result<Report, Error>
+    pub async fn run_async(&mut self) -> Result<Report, Error>
     where
         C: AsyncMigrate + Send,
     {

--- a/refinery_core/src/runner.rs
+++ b/refinery_core/src/runner.rs
@@ -462,22 +462,20 @@ where
     fn next(&mut self) -> Option<Self::Item> {
         match self.failed {
             true => None,
-            false => {
-                self.items.pop_front().map(|migration| {
-                    sync_migrate(
-                        self.connection,
-                        vec![migration],
-                        self.target,
-                        &self.migration_table_name,
-                    )
-                        .map(|r| r.applied_migrations.first().cloned().unwrap())
-                        .map_err(|e| {
-                            error!("migration failed: {e:?}");
-                            self.failed = true;
-                            e
-                        })
+            false => self.items.pop_front().map(|migration| {
+                sync_migrate(
+                    self.connection,
+                    vec![migration],
+                    self.target,
+                    &self.migration_table_name,
+                )
+                .map(|r| r.applied_migrations.first().cloned().unwrap())
+                .map_err(|e| {
+                    error!("migration failed: {e:?}");
+                    self.failed = true;
+                    e
                 })
-            }
+            }),
         }
     }
 }

--- a/refinery_core/src/traits/async.rs
+++ b/refinery_core/src/traits/async.rs
@@ -1,13 +1,12 @@
 use crate::error::WrapMigrationError;
 use crate::traits::{
     verify_migrations, ASSERT_MIGRATIONS_TABLE_QUERY, GET_APPLIED_MIGRATIONS_QUERY,
-    GET_LAST_APPLIED_MIGRATION_QUERY,
+    GET_LAST_APPLIED_MIGRATION_QUERY, insert_migration_query
 };
 use crate::{Error, Migration, Report, Target};
 
 use async_trait::async_trait;
 use std::string::ToString;
-use time::format_description::well_known::Rfc3339;
 
 #[async_trait]
 pub trait AsyncTransaction {
@@ -42,19 +41,11 @@ async fn migrate<T: AsyncTransaction>(
 
         log::info!("applying migration: {}", migration);
         migration.set_applied();
-        let update_query = &format!(
-            "INSERT INTO {} (version, name, applied_on, checksum) VALUES ({}, '{}', '{}', '{}')",
-            // safe to call unwrap as we just converted it to applied, and we are sure it can be formatted according to RFC 33339
-            migration_table_name,
-            migration.version(),
-            migration.name(),
-            migration.applied_on().unwrap().format(&Rfc3339).unwrap(),
-            migration.checksum()
-        );
+        let update_query = insert_migration_query(&migration, migration_table_name);
         transaction
             .execute(&[
                 migration.sql().as_ref().expect("sql must be Some!"),
-                update_query,
+                &update_query,
             ])
             .await
             .migration_err(
@@ -83,15 +74,7 @@ async fn migrate_grouped<T: AsyncTransaction>(
         }
 
         migration.set_applied();
-        let query = format!(
-            "INSERT INTO {} (version, name, applied_on, checksum) VALUES ({}, '{}', '{}', '{}')",
-            // safe to call unwrap as we just converted it to applied, and we are sure it can be formatted according to RFC 33339
-            migration_table_name,
-            migration.version(),
-            migration.name(),
-            migration.applied_on().unwrap().format(&Rfc3339).unwrap(),
-            migration.checksum()
-        );
+        let query = insert_migration_query(&migration, migration_table_name);
 
         let sql = migration.sql().expect("sql must be Some!").to_string();
 

--- a/refinery_core/src/traits/async.rs
+++ b/refinery_core/src/traits/async.rs
@@ -1,7 +1,7 @@
 use crate::error::WrapMigrationError;
 use crate::traits::{
-    verify_migrations, ASSERT_MIGRATIONS_TABLE_QUERY, GET_APPLIED_MIGRATIONS_QUERY,
-    GET_LAST_APPLIED_MIGRATION_QUERY, insert_migration_query
+    insert_migration_query, verify_migrations, ASSERT_MIGRATIONS_TABLE_QUERY,
+    GET_APPLIED_MIGRATIONS_QUERY, GET_LAST_APPLIED_MIGRATION_QUERY,
 };
 use crate::{Error, Migration, Report, Target};
 

--- a/refinery_core/src/traits/mod.rs
+++ b/refinery_core/src/traits/mod.rs
@@ -1,3 +1,5 @@
+use time::format_description::well_known::Rfc3339;
+
 pub mod r#async;
 pub mod sync;
 
@@ -87,6 +89,18 @@ pub(crate) fn verify_migrations(
     // exist on the file system and have the same checksum, and all migrations found
     // on the file system are either on the database, or greater than the current, and therefore going to be applied
     Ok(to_be_applied)
+}
+
+pub(crate) fn insert_migration_query(migration: &Migration, migration_table_name: &str) -> String {
+    format!(
+        "INSERT INTO {} (version, name, applied_on, checksum) VALUES ({}, '{}', '{}', '{}')",
+        // safe to call unwrap as we just converted it to applied, and we are sure it can be formatted according to RFC 33339
+        migration_table_name,
+        migration.version(),
+        migration.name(),
+        migration.applied_on().unwrap().format(&Rfc3339).unwrap(),
+        migration.checksum()
+    )
 }
 
 pub(crate) const ASSERT_MIGRATIONS_TABLE_QUERY: &str =

--- a/refinery_core/src/traits/sync.rs
+++ b/refinery_core/src/traits/sync.rs
@@ -54,6 +54,7 @@ fn migrate_batch<T: Transaction>(
             }
         }
 
+        log::info!("applying migration: {}", migration);
         migration.set_applied();
         let insert_migration = insert_migration_query(&migration, migration_table_name);
         let migration_sql = migration.sql().expect("sql must be Some!").to_string();

--- a/refinery_core/src/traits/sync.rs
+++ b/refinery_core/src/traits/sync.rs
@@ -92,10 +92,10 @@ fn migrate_batch<T: Transaction>(
             .execute(refs.as_ref())
             .migration_err("error applying migrations", None)?;
     } else {
-        for update in refs {
+        for (i, update) in refs.iter().enumerate() {
             transaction
                 .execute(&[update])
-                .migration_err("error applying update", None)?;
+                .migration_err("error applying update", Some(&applied_migrations[0..i / 2]))?;
         }
     }
 

--- a/refinery_core/src/traits/sync.rs
+++ b/refinery_core/src/traits/sync.rs
@@ -1,8 +1,7 @@
-
 use crate::error::WrapMigrationError;
 use crate::traits::{
-    verify_migrations, ASSERT_MIGRATIONS_TABLE_QUERY, GET_APPLIED_MIGRATIONS_QUERY,
-    GET_LAST_APPLIED_MIGRATION_QUERY, insert_migration_query
+    insert_migration_query, verify_migrations, ASSERT_MIGRATIONS_TABLE_QUERY,
+    GET_APPLIED_MIGRATIONS_QUERY, GET_LAST_APPLIED_MIGRATION_QUERY,
 };
 use crate::{Error, Migration, Report, Target};
 
@@ -16,7 +15,7 @@ pub trait Query<T>: Transaction {
     fn query(&mut self, query: &str) -> Result<T, Self::Error>;
 }
 
-pub (crate) fn migrate<T: Transaction>(
+pub(crate) fn migrate<T: Transaction>(
     transaction: &mut T,
     migrations: Vec<Migration>,
     target: Target,
@@ -31,7 +30,7 @@ fn migrate_grouped<T: Transaction>(
     target: Target,
     migration_table_name: &str,
 ) -> Result<Report, Error> {
-    migrate_batch(transaction, migrations,target,migration_table_name, true)
+    migrate_batch(transaction, migrations, target, migration_table_name, true)
 }
 
 fn migrate_batch<T: Transaction>(
@@ -76,7 +75,7 @@ fn migrate_batch<T: Transaction>(
                 "going to apply batch migrations in single transaction: {:#?}",
                 applied_migrations.iter().map(ToString::to_string)
             );
-        },
+        }
         (Target::Latest | Target::Version(_), false) => {
             log::info!(
                 "preparing to apply {} migrations: {:#?}",
@@ -146,11 +145,12 @@ where
         Ok(migrations)
     }
 
-    fn get_unapplied_migrations(&mut self,
-                                migrations: &[Migration],
-                                abort_divergent: bool,
-                                abort_missing: bool,
-                                migration_table_name: &str,
+    fn get_unapplied_migrations(
+        &mut self,
+        migrations: &[Migration],
+        abort_divergent: bool,
+        abort_missing: bool,
+        migration_table_name: &str,
     ) -> Result<Vec<Migration>, Error> {
         self.assert_migrations_table(migration_table_name)?;
 
@@ -179,10 +179,12 @@ where
         target: Target,
         migration_table_name: &str,
     ) -> Result<Report, Error> {
-        let migrations = self.get_unapplied_migrations(migrations,
-                                                       abort_divergent,
-                                                       abort_missing,
-                                                       migration_table_name)?;
+        let migrations = self.get_unapplied_migrations(
+            migrations,
+            abort_divergent,
+            abort_missing,
+            migration_table_name,
+        )?;
 
         if grouped || matches!(target, Target::Fake | Target::FakeVersion(_)) {
             migrate_grouped(self, migrations, target, migration_table_name)

--- a/refinery_macros/src/lib.rs
+++ b/refinery_macros/src/lib.rs
@@ -77,7 +77,7 @@ pub fn embed_migrations(input: TokenStream) -> TokenStream {
             let mig_mod = quote! {pub mod #ident {
                 #rs_content
                 // also include the file as str so we trigger recompilation if it changes
-                const _recompile_if_changed: &str = include_str!(#path);
+                const _RECOMPILE_IF_CHANGED: &str = include_str!(#path);
             }};
             _migrations.push(quote! {(#filename, #ident::migration())});
             migrations_mods.push(mig_mod);

--- a/refinery_macros/src/lib.rs
+++ b/refinery_macros/src/lib.rs
@@ -19,13 +19,13 @@ pub(crate) fn crate_root() -> PathBuf {
 fn migration_fn_quoted<T: ToTokens>(_migrations: Vec<T>) -> TokenStream2 {
     let result = quote! {
         use refinery::{Migration, Runner};
-        pub fn runner() -> Runner {
+        pub fn runner<'a, C>(connection: &'a mut C) -> Runner<'a, C> {
             let quoted_migrations: Vec<(&str, String)> = vec![#(#_migrations),*];
             let mut migrations: Vec<Migration> = Vec::new();
             for module in quoted_migrations.into_iter() {
                 migrations.push(Migration::unapplied(module.0, &module.1).unwrap());
             }
-            Runner::new(&migrations)
+            Runner::new(&migrations, connection)
         }
     };
     result
@@ -103,13 +103,13 @@ mod tests {
         let migs = vec![quote!("V1__first", "valid_sql_file")];
         let expected = concat! {
             "use refinery :: { Migration , Runner } ; ",
-            "pub fn runner () -> Runner { ",
+            "pub fn runner < 'a , C > (connection : & 'a mut C) -> Runner < 'a , C > { ",
             "let quoted_migrations : Vec < (& str , String) > = vec ! [\"V1__first\" , \"valid_sql_file\"] ; ",
             "let mut migrations : Vec < Migration > = Vec :: new () ; ",
             "for module in quoted_migrations . into_iter () { ",
             "migrations . push (Migration :: unapplied (module . 0 , & module . 1) . unwrap ()) ; ",
             "} ",
-            "Runner :: new (& migrations) }"
+            "Runner :: new (& migrations , connection) }"
         };
         assert_eq!(expected, migration_fn_quoted(migs).to_string());
     }


### PR DESCRIPTION
- adds an impl of `IntoIterator` for `Runner`, as a third way to run migrations beyond `run()` and `run_async()`
- moves the `connection` argument from `run()` to `Runner::new()`
- refactors some migration code to reduce duplication between `sync`/`async` implementations and make handling of `Target::Fake` more consistent