### PR TITLE
feat: add SurrealDB support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,19 @@ jobs:
       - run: cargo install --path ./refinery_cli --no-default-features --features=mssql
       - run: cd refinery && cargo test --features tiberius-config --test tiberius -- --test-threads 1
 
+  test-surrealdb:
+    name: Test surrealdb
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust: [stable, nightly, 1.56.0]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+      - run: cd refinery && cargo test --features surrealdb --test surreal -- --test-threads 1
+
   doc:
     name: Build docs
     runs-on: ubuntu-latest

--- a/refinery/Cargo.toml
+++ b/refinery/Cargo.toml
@@ -22,10 +22,13 @@ tokio-postgres = ["refinery-core/tokio-postgres"]
 mysql_async = ["refinery-core/mysql_async"]
 tiberius = ["refinery-core/tiberius"]
 tiberius-config = ["refinery-core/tiberius", "refinery-core/tiberius-config"]
+surrealdb = ["refinery-core/surrealdb"]
 
 [dependencies]
 refinery-core = { version = "0.8.11", path = "../refinery_core" }
 refinery-macros = { version = "0.8.11", path = "../refinery_macros" }
+serde = { version = "1.0.193", features = ["derive"] }
+serde_json = "1.0.108"
 
 [dev-dependencies]
 barrel = { git = "https://github.com/jxs/barrel", features = ["sqlite3", "pg", "mysql", "mssql"] }

--- a/refinery/tests/migrations_surreal/V1__initial.rs
+++ b/refinery/tests/migrations_surreal/V1__initial.rs
@@ -1,0 +1,8 @@
+pub fn migration() -> String {
+    r##"
+        DEFINE TABLE user SCHEMAFULL;
+
+        DEFINE FIELD first_name ON TABLE user TYPE string;
+        DEFINE FIELD last_name ON TABLE user TYPE string;
+    "##.to_string()
+}

--- a/refinery/tests/migrations_surreal/V2__add_email.surql
+++ b/refinery/tests/migrations_surreal/V2__add_email.surql
@@ -1,0 +1,1 @@
+DEFINE FIELD email ON TABLE user TYPE string;

--- a/refinery/tests/surreal.rs
+++ b/refinery/tests/surreal.rs
@@ -1,0 +1,197 @@
+// needed to be able to embed the other migrations, the surrealdb migrations don't need that
+use barrel::backend::Pg as Sql;
+
+#[cfg(feature = "surrealdb")]
+mod surreal {
+    use refinery_core::surrealdb::engine::local::{Db, Mem};
+    use refinery_core::Migration;
+    use refinery_core::{surrealdb, AsyncMigrate};
+    use refinery_macros::embed_migrations;
+    use serde::{Deserialize, Serialize};
+    use serde_json;
+    use time::OffsetDateTime;
+
+    const DEFAULT_TABLE_NAME: &str = "refinery_schema_history";
+
+    fn get_migrations() -> Vec<Migration> {
+        embed_migrations!("./tests/migrations_surreal");
+
+        let migration1 =
+            Migration::unapplied("V1__initial.rs", &migrations::V1__initial::migration()).unwrap();
+
+        let migration2 = Migration::unapplied(
+            "V2__add_email.surql",
+            include_str!("./migrations_surreal/V2__add_email.surql"),
+        )
+        .unwrap();
+
+        let migration3 = Migration::unapplied("V3__add_cars_table", "DEFINE TABLE cars;").unwrap();
+
+        vec![migration1, migration2, migration3]
+    }
+
+    async fn get_db() -> surrealdb::Surreal<Db> {
+        let db = surrealdb::Surreal::new::<Mem>(()).await.unwrap();
+        db.use_ns("refinery_test")
+            .use_db("refinery_test")
+            .await
+            .unwrap();
+
+        db
+    }
+
+    mod embedded {
+        use refinery::embed_migrations;
+        embed_migrations!("./tests/migrations_surreal");
+    }
+
+    #[tokio::test]
+    async fn report_contains_applied_migrations() {
+        let mut db = get_db().await;
+
+        let report = embedded::migrations::runner()
+            .run_async(&mut db)
+            .await
+            .unwrap();
+
+        let migrations = get_migrations();
+        let applied_migrations = report.applied_migrations();
+
+        assert_eq!(2, applied_migrations.len());
+
+        assert_eq!(migrations[0].version(), applied_migrations[0].version());
+        assert_eq!(migrations[1].version(), applied_migrations[1].version());
+
+        assert_eq!(migrations[0].name(), applied_migrations[0].name());
+        assert_eq!(migrations[1].name(), applied_migrations[1].name());
+
+        assert_eq!(migrations[0].checksum(), applied_migrations[0].checksum());
+        assert_eq!(migrations[1].checksum(), applied_migrations[1].checksum());
+    }
+
+    #[tokio::test]
+    async fn creates_migration_table() {
+        let mut db = get_db().await;
+
+        embedded::migrations::runner()
+            .run_async(&mut db)
+            .await
+            .unwrap();
+
+        #[derive(Deserialize)]
+        struct InfoResult {
+            fields: serde_json::Value,
+        }
+
+        let result: Option<InfoResult> = db
+            .query(format!("INFO FOR TABLE {};", DEFAULT_TABLE_NAME))
+            .await
+            .unwrap()
+            .take(0)
+            .unwrap();
+
+        // assert that 4 fields exist: applied_on, checksum, name, version
+        assert_eq!(4, result.unwrap().fields.as_object().unwrap().len());
+    }
+
+    #[tokio::test]
+    async fn creates_migration_table_grouped_migrations() {
+        let mut db = get_db().await;
+
+        embedded::migrations::runner()
+            .set_grouped(true)
+            .run_async(&mut db)
+            .await
+            .unwrap();
+
+        #[derive(Deserialize)]
+        struct InfoResult {
+            fields: serde_json::Value,
+        }
+
+        let result: Option<InfoResult> = db
+            .query(format!("INFO FOR TABLE {};", DEFAULT_TABLE_NAME))
+            .await
+            .unwrap()
+            .take(0)
+            .unwrap();
+
+        // assert that 4 fields exist: applied_on, checksum, name, version
+        assert_eq!(4, result.unwrap().fields.as_object().unwrap().len());
+    }
+
+    #[tokio::test]
+    async fn applies_migration_grouped() {
+        let mut db = get_db().await;
+
+        embedded::migrations::runner()
+            .set_grouped(true)
+            .run_async(&mut db)
+            .await
+            .unwrap();
+
+        #[derive(Debug, Serialize, Deserialize)]
+        struct User {
+            first_name: String,
+            last_name: String,
+            email: String,
+        }
+
+        let result: Option<User> = db
+            .create(("user", "john"))
+            .content(User {
+                first_name: "John".into(),
+                last_name: "Doe".into(),
+                email: "john@example.com".into(),
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result.unwrap().email, "john@example.com");
+    }
+
+    #[tokio::test]
+    async fn updates_schema_history() {
+        let mut db = get_db().await;
+
+        embedded::migrations::runner()
+            .run_async(&mut db)
+            .await
+            .unwrap();
+
+        let current = db
+            .get_last_applied_migration(DEFAULT_TABLE_NAME)
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(2, current.version());
+        assert_eq!(
+            OffsetDateTime::now_utc().date(),
+            current.applied_on().unwrap().date()
+        );
+    }
+
+    #[tokio::test]
+    async fn updates_schema_history_grouped() {
+        let mut db = get_db().await;
+
+        embedded::migrations::runner()
+            .set_grouped(true)
+            .run_async(&mut db)
+            .await
+            .unwrap();
+
+        let current = db
+            .get_last_applied_migration(DEFAULT_TABLE_NAME)
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(2, current.version());
+        assert_eq!(
+            OffsetDateTime::now_utc().date(),
+            current.applied_on().unwrap().date()
+        );
+    }
+}

--- a/refinery_cli/Cargo.toml
+++ b/refinery_cli/Cargo.toml
@@ -21,6 +21,7 @@ mysql = ["refinery-core/mysql"]
 sqlite = ["refinery-core/rusqlite"]
 sqlite-bundled = ["sqlite", "refinery-core/rusqlite-bundled"]
 mssql = ["refinery-core/tiberius-config", "tokio"]
+surrealdb = ["refinery-core/surrealdb"]
 
 [dependencies]
 refinery-core = { version = "0.8.11", path = "../refinery_core", default-features = false }

--- a/refinery_cli/src/migrate.rs
+++ b/refinery_cli/src/migrate.rs
@@ -60,10 +60,10 @@ fn run_migrations(
     };
 
     match config.db_type() {
-        ConfigDbType::Mssql => {
+        _db_type @ (ConfigDbType::Mssql | ConfigDbType::Surreal) => {
             cfg_if::cfg_if! {
                 // tiberius is an async driver so we spawn tokio runtime and run the migrations
-                if #[cfg(feature = "mssql")] {
+                if #[cfg(any(feature = "mssql", feature = "surrealdb"))] {
                     use tokio::runtime::Builder;
 
                     let runtime = Builder::new_current_thread()
@@ -82,7 +82,7 @@ fn run_migrations(
                             .await
                     })?;
                 } else {
-                    panic!("tried to migrate async from config for a mssql database, but mssql feature was not enabled!");
+                    panic!("tried to migrate async from config for a {:?} database, but it's matching feature was not enabled!", _db_type);
                 }
             }
         }

--- a/refinery_cli/src/setup.rs
+++ b/refinery_cli/src/setup.rs
@@ -100,7 +100,6 @@ fn get_config_from_input() -> Result<Config> {
                 //remove \n
                 db_namespace.pop();
                 config = config.set_db_namespace(db_namespace.trim());
-                return Ok(config);
             } else {
                 panic!("tried to migrate async from config for a SurrealDB database, but surrealdb feature was not enabled!");
             }

--- a/refinery_core/Cargo.toml
+++ b/refinery_core/Cargo.toml
@@ -15,6 +15,7 @@ tiberius = ["dep:tiberius", "futures", "tokio", "tokio/net"]
 tiberius-config = ["tiberius", "tokio", "tokio-util"]
 tokio-postgres = ["dep:tokio-postgres", "tokio", "tokio/rt"]
 mysql_async = ["dep:mysql_async"]
+surrealdb = ["dep:surrealdb", "surrealdb/kv-mem", "surrealdb/protocol-ws"]
 
 [dependencies]
 async-trait = "0.1"
@@ -36,6 +37,7 @@ tokio-postgres = { version = ">= 0.5, <= 0.7", optional = true }
 mysql = { version = ">= 21.0.0, <= 24", optional = true, default-features = false, features = ["minimal"] }
 mysql_async = { version = ">= 0.28, <= 0.33", optional = true, default-features = false, features = ["minimal"] }
 tiberius = { version = ">= 0.7, <= 0.12", optional = true, default-features = false }
+surrealdb = { version = "1.0.0", optional = true }
 tokio = { version = "1.0", optional = true }
 futures = { version = "0.3.16", optional = true, features = ["async-await"] }
 tokio-util = { version = "0.7.7", features = ["compat"], optional = true }

--- a/refinery_core/src/drivers/config.rs
+++ b/refinery_core/src/drivers/config.rs
@@ -168,7 +168,8 @@ macro_rules! with_connection_async {
                         };
 
                         let config = $config;
-                        let db = Surreal::new::<Ws>(config.db_host().unwrap()).await.migration_err("could not connect to database", None)?;
+                        let endpoint = format!("{}:{}", config.db_host().unwrap(), config.db_port().unwrap());
+                        let db = Surreal::new::<Ws>(endpoint.clone()).await.migration_err(format!("could not connect to database at {}", endpoint).as_str(), None)?;
                         db.use_ns(config.db_namespace().unwrap())
                             .use_db(config.db_name().unwrap())
                             .await.migration_err("could not use namespace or db", None)?;

--- a/refinery_core/src/drivers/mod.rs
+++ b/refinery_core/src/drivers/mod.rs
@@ -16,4 +16,7 @@ pub mod mysql;
 #[cfg(feature = "tiberius")]
 pub mod tiberius;
 
+#[cfg(feature = "surrealdb")]
+pub mod surrealdb;
+
 mod config;

--- a/refinery_core/src/drivers/surrealdb.rs
+++ b/refinery_core/src/drivers/surrealdb.rs
@@ -1,0 +1,113 @@
+use crate::error::WrapMigrationError;
+use crate::traits::r#async::{AsyncQuery, AsyncTransaction};
+use crate::{AsyncMigrate, Error, Migration};
+use async_trait::async_trait;
+use serde::Deserialize;
+use surrealdb::Surreal;
+use time::format_description::well_known::Rfc3339;
+use time::OffsetDateTime;
+
+#[derive(Deserialize)]
+struct MigrationEntry {
+    version: i32,
+    name: String,
+    applied_on: String,
+    checksum: String,
+}
+
+async fn query_applied_migrations<C: surrealdb::Connection>(
+    db: &Surreal<C>,
+    query: &str,
+) -> Result<Vec<Migration>, surrealdb::Error> {
+    let rows: Vec<MigrationEntry> = db.query(query).await?.take(0)?;
+    let mut applied = Vec::new();
+    for entry in rows.into_iter() {
+        let version = entry.version;
+        let applied_on: String = entry.applied_on;
+        // Safe to call unwrap, as we stored it in RFC3339 format on the database
+        let applied_on = OffsetDateTime::parse(&applied_on, &Rfc3339).unwrap();
+
+        let checksum: String = entry.checksum;
+
+        applied.push(Migration::applied(
+            version,
+            entry.name,
+            applied_on,
+            checksum
+                .parse::<u64>()
+                .expect("checksum must be a valid u64"),
+        ));
+    }
+    Ok(applied)
+}
+
+#[async_trait]
+impl<C: surrealdb::Connection> AsyncQuery<Vec<Migration>> for Surreal<C> {
+    async fn query(&mut self, query: &str) -> Result<Vec<Migration>, Self::Error> {
+        Ok(query_applied_migrations(self, query).await?)
+    }
+}
+
+#[async_trait]
+impl<C: surrealdb::Connection> AsyncTransaction for Surreal<C> {
+    type Error = surrealdb::Error;
+    async fn execute(&mut self, query: &[&str]) -> Result<usize, Self::Error> {
+        let queries = query.join("\n");
+        let result = Surreal::query(self, "BEGIN TRANSACTION")
+            .query(queries)
+            .query("COMMIT TRANSACTION")
+            .await?;
+        Ok(result.num_statements())
+    }
+}
+
+const ASSERT_MIGRATIONS_TABLE_QUERY: &'static str = r##"
+    DEFINE TABLE %MIGRATION_TABLE_NAME% SCHEMAFULL;
+    DEFINE FIELD version ON TABLE %MIGRATION_TABLE_NAME% TYPE int;
+    DEFINE FIELD name ON TABLE %MIGRATION_TABLE_NAME% TYPE string;
+    DEFINE FIELD applied_on ON TABLE %MIGRATION_TABLE_NAME% TYPE string;
+    DEFINE FIELD checksum ON TABLE %MIGRATION_TABLE_NAME% TYPE string;
+"##;
+
+const GET_APPLIED_MIGRATIONS_QUERY: &'static str = r##"
+    SELECT version, name, applied_on, checksum
+    FROM %MIGRATION_TABLE_NAME% ORDER BY version COLLATE ASC;
+"##;
+
+const GET_LAST_APPLIED_MIGRATION_QUERY: &'static str = r##"
+    SELECT version, name, applied_on, checksum
+    FROM %MIGRATION_TABLE_NAME% ORDER BY version COLLATE DESC LIMIT 1;
+"##;
+
+#[async_trait]
+impl<C: surrealdb::Connection> AsyncMigrate for Surreal<C> {
+    fn assert_migrations_table_query(migration_table_name: &str) -> String {
+        ASSERT_MIGRATIONS_TABLE_QUERY.replace("%MIGRATION_TABLE_NAME%", migration_table_name)
+    }
+
+    async fn get_last_applied_migration(
+        &mut self,
+        migration_table_name: &str,
+    ) -> Result<Option<Migration>, Error> {
+        let table_query = GET_LAST_APPLIED_MIGRATION_QUERY
+            .replace("%MIGRATION_TABLE_NAME%", migration_table_name);
+
+        let mut results = query_applied_migrations(self, table_query.as_str())
+            .await
+            .migration_err("failed to get applied migrations", None)?;
+
+        Ok(results.pop())
+    }
+
+    async fn get_applied_migrations(
+        &mut self,
+        migration_table_name: &str,
+    ) -> Result<Vec<Migration>, Error> {
+        let table_query =
+            GET_APPLIED_MIGRATIONS_QUERY.replace("%MIGRATION_TABLE_NAME%", migration_table_name);
+
+        Ok(query_applied_migrations(self, table_query.as_str())
+            .await
+            .migration_err("failed to get applied migrations", None)?)
+    }
+}

--- a/refinery_core/src/lib.rs
+++ b/refinery_core/src/lib.rs
@@ -28,3 +28,6 @@ pub use mysql_async;
 
 #[cfg(feature = "tiberius")]
 pub use tiberius;
+
+#[cfg(feature = "surrealdb")]
+pub use surrealdb;

--- a/refinery_core/src/traits/async.rs
+++ b/refinery_core/src/traits/async.rs
@@ -43,7 +43,7 @@ async fn migrate<T: AsyncTransaction>(
         log::info!("applying migration: {}", migration);
         migration.set_applied();
         let update_query = &format!(
-            "INSERT INTO {} (version, name, applied_on, checksum) VALUES ({}, '{}', '{}', '{}')",
+            "INSERT INTO {} (version, name, applied_on, checksum) VALUES ({}, '{}', '{}', '{}');",
             // safe to call unwrap as we just converted it to applied, and we are sure it can be formatted according to RFC 33339
             migration_table_name,
             migration.version(),
@@ -84,7 +84,7 @@ async fn migrate_grouped<T: AsyncTransaction>(
 
         migration.set_applied();
         let query = format!(
-            "INSERT INTO {} (version, name, applied_on, checksum) VALUES ({}, '{}', '{}', '{}')",
+            "INSERT INTO {} (version, name, applied_on, checksum) VALUES ({}, '{}', '{}', '{}');",
             // safe to call unwrap as we just converted it to applied, and we are sure it can be formatted according to RFC 33339
             migration_table_name,
             migration.version(),
@@ -186,10 +186,7 @@ where
             .migration_err("error asserting migrations table", None)?;
 
         let applied_migrations = self
-            .query(
-                &GET_APPLIED_MIGRATIONS_QUERY
-                    .replace("%MIGRATION_TABLE_NAME%", migration_table_name),
-            )
+            .get_applied_migrations(migration_table_name)
             .await
             .migration_err("error getting current schema version", None)?;
 

--- a/refinery_core/src/util.rs
+++ b/refinery_core/src/util.rs
@@ -18,8 +18,8 @@ pub enum MigrationType {
 impl MigrationType {
     fn file_match_re(&self) -> Regex {
         let ext = match self {
-            MigrationType::All => "(rs|sql)",
-            MigrationType::Sql => "sql",
+            MigrationType::All => "(rs|sql|surql)",
+            MigrationType::Sql => "sql|surql",
         };
         let re_str = format!(r"^(U|V)(\d+(?:\.\d+)?)__(\w+)\.{}$", ext);
         Regex::new(re_str.as_str()).unwrap()

--- a/refinery_macros/src/lib.rs
+++ b/refinery_macros/src/lib.rs
@@ -66,7 +66,7 @@ pub fn embed_migrations(input: TokenStream) -> TokenStream {
         let path = migration.display().to_string();
         let extension = migration.extension().unwrap();
 
-        if extension == "sql" {
+        if extension == "sql" || extension == "surql" {
             _migrations.push(quote! {(#filename, include_str!(#path).to_string())});
         } else if extension == "rs" {
             let rs_content = fs::read_to_string(&path)
@@ -81,6 +81,8 @@ pub fn embed_migrations(input: TokenStream) -> TokenStream {
             }};
             _migrations.push(quote! {(#filename, #ident::migration())});
             migrations_mods.push(mig_mod);
+        } else {
+            panic!("invalid migration file {:?}", extension);
         }
     }
 


### PR DESCRIPTION
adds support for SurrealDB.  I had to modify some SQL a bit and add new query constants for Surreal because of its different SurQL syntax.
This uses Surreal<Mem> for testing, it should act the same like a remote database.

The current tests pass, but the tests with the broken migrations are still missing.

Closes #294 