### PR TITLE
refinery-cli: update toml dependency

### DIFF
--- a/refinery_cli/Cargo.toml
+++ b/refinery_cli/Cargo.toml
@@ -26,7 +26,7 @@ mssql = ["refinery-core/tiberius-config", "tokio"]
 refinery-core = { version = "0.8.11", path = "../refinery_core", default-features = false }
 clap = { version = "4", features = ["derive"] }
 human-panic = "1.1.3"
-toml = "0.7"
+toml = "0.8"
 env_logger = "0.10"
 log = "0.4"
 anyhow = "1"


### PR DESCRIPTION
refinery-core is already using toml 0.8