### PR TITLE
Make `serde`, `toml` deps optional

### DIFF
--- a/refinery/Cargo.toml
+++ b/refinery/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["database"]
 edition = "2018"
 
 [features]
-default = []
+default = ["toml"]
 rusqlite-bundled = ["refinery-core/rusqlite-bundled"]
 rusqlite = ["refinery-core/rusqlite"]
 postgres = ["refinery-core/postgres"]
@@ -22,6 +22,8 @@ tokio-postgres = ["refinery-core/tokio-postgres"]
 mysql_async = ["refinery-core/mysql_async"]
 tiberius = ["refinery-core/tiberius"]
 tiberius-config = ["refinery-core/tiberius", "refinery-core/tiberius-config"]
+serde = ["refinery-core/serde"]
+toml = ["refinery-core/toml"]
 
 [dependencies]
 refinery-core = { version = "0.8.12", path = "../refinery_core" }

--- a/refinery_cli/Cargo.toml
+++ b/refinery_cli/Cargo.toml
@@ -23,7 +23,7 @@ sqlite-bundled = ["sqlite", "refinery-core/rusqlite-bundled"]
 mssql = ["refinery-core/tiberius-config", "tokio"]
 
 [dependencies]
-refinery-core = { version = "0.8.12", path = "../refinery_core", default-features = false }
+refinery-core = { version = "0.8.12", path = "../refinery_core", default-features = false, features = ["toml"]  }
 clap = { version = "4", features = ["derive"] }
 human-panic = "1.1.3"
 toml = "0.8"

--- a/refinery_core/Cargo.toml
+++ b/refinery_core/Cargo.toml
@@ -15,16 +15,16 @@ tiberius = ["dep:tiberius", "futures", "tokio", "tokio/net"]
 tiberius-config = ["tiberius", "tokio", "tokio-util"]
 tokio-postgres = ["dep:tokio-postgres", "tokio", "tokio/rt"]
 mysql_async = ["dep:mysql_async"]
+serde = ["dep:serde"]
+toml = ["serde", "dep:toml"]
 
 [dependencies]
 async-trait = "0.1"
 cfg-if = "1.0"
 log = "0.4"
 regex = "1"
-serde = { version = "1", features = ["derive"] }
 siphasher = "1.0"
 thiserror = "1"
-toml = "0.8.8"
 url = "2.0"
 walkdir = "2.3.1"
 
@@ -39,6 +39,8 @@ tokio = { version = "1.0", optional = true }
 futures = { version = "0.3.16", optional = true, features = ["async-await"] }
 tokio-util = { version = "0.7.7", features = ["compat"], optional = true }
 time = { version = "0.3.5", features = ["parsing", "formatting"] }
+serde = { version = "1", features = ["derive"], optional = true }
+toml = { version = "0.8.8", optional = true }
 
 [dev-dependencies]
 barrel = { git = "https://github.com/jxs/barrel", features = ["sqlite3", "pg", "mysql", "mssql"] }

--- a/refinery_core/src/config.rs
+++ b/refinery_core/src/config.rs
@@ -1,6 +1,5 @@
 use crate::error::Kind;
 use crate::Error;
-use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -9,12 +8,14 @@ use url::Url;
 
 // refinery config file used by migrate_from_config if migration from a Config struct is preferred instead of using the macros
 // Config can either be instanced with [`Config::new`] or retrieved from a config file with [`Config::from_file_location`]
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Config {
     main: Main,
 }
 
-#[derive(Clone, Copy, Serialize, Deserialize, PartialEq, Debug)]
+#[derive(Clone, Copy, PartialEq, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ConfigDbType {
     Mysql,
     Postgres,
@@ -52,6 +53,7 @@ impl Config {
     }
 
     /// create a new Config instance from a config file located on the file system
+    #[cfg(feature = "toml")]
     pub fn from_file_location<T: AsRef<Path>>(location: T) -> Result<Config, Error> {
         let file = std::fs::read_to_string(&location).map_err(|err| {
             Error::new(
@@ -259,7 +261,8 @@ impl FromStr for Config {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 struct Main {
     db_type: ConfigDbType,
     db_path: Option<PathBuf>,


### PR DESCRIPTION
We make `serde` and `toml` dependencies optional, enabled by default, using default features.

Config[^1] already allows to configure it programmatically, using the `set_xxx` methods. However, refinery-core (used by refinery crate) uses serde by default to support serialization and deserialization of this type. This is unnecessary if one doesn't need the `refinery-cli` and also configures it programmatically.

On top of that, refinery makes the assumption that `Toml` format will be used to deserialize/serialize this type, as toml dependency is used as well in refinery-core by default. Again it's not always the case, this is more related with `refinery-cli`.

Let's declare both `serde` and `toml` dependencies as optional, under a feature flag. Apparently, if `toml` dependency is enabled, `serde` should be enabled as well, thus `toml` feature enables `serde` feature automatically.

For `refinery-cli`, we just make sure to enable `toml` (and consequently `serde`) feature when using the `refinery` dependency, since it's impossible fo `refinery-cli` to work without these 2 dependencies.

However, for `refinery`, we declare them under the default features: they will be enabled by default, unless the host crate specifies `default-features = false`.

Fixes #308.

[^1]: https://docs.rs/refinery/latest/refinery/config/struct.Config.html