### PR TITLE
Dynamic migration dicovery, bug fix

### DIFF
--- a/refinery/src/lib.rs
+++ b/refinery/src/lib.rs
@@ -32,7 +32,7 @@ for more examples refer to the [examples](https://github.com/rust-db/refinery/tr
 */
 
 pub use refinery_core::config;
-pub use refinery_core::{error, Error, Migration, Report, Runner, Target};
+pub use refinery_core::{error, load_sql_migrations, Error, Migration, Report, Runner, Target};
 #[doc(hidden)]
 pub use refinery_core::{AsyncMigrate, Migrate};
 pub use refinery_macros::embed_migrations;

--- a/refinery_core/src/error.rs
+++ b/refinery_core/src/error.rs
@@ -66,6 +66,9 @@ pub enum Kind {
     /// An Error from an underlying database connection Error
     #[error("`{0}`, `{1}`")]
     Connection(String, #[source] Box<dyn std::error::Error + Sync + Send>),
+    /// An Error from an invalid migration file (not UTF-8 etc)
+    #[error("invalid migration file at path {0}, {1}")]
+    InvalidMigrationFile(PathBuf, std::io::Error),
 }
 
 // Helper trait for adding custom messages and applied migrations to Connection error's.

--- a/refinery_core/src/lib.rs
+++ b/refinery_core/src/lib.rs
@@ -9,7 +9,7 @@ pub use crate::error::Error;
 pub use crate::runner::{Migration, Report, Runner, Target};
 pub use crate::traits::r#async::AsyncMigrate;
 pub use crate::traits::sync::Migrate;
-pub use crate::util::{find_migration_files, MigrationType};
+pub use crate::util::{find_migration_files, load_sql_migrations, MigrationType};
 
 #[cfg(feature = "rusqlite")]
 pub use rusqlite;

--- a/refinery_core/src/traits/mod.rs
+++ b/refinery_core/src/traits/mod.rs
@@ -115,7 +115,7 @@ pub(crate) const GET_APPLIED_MIGRATIONS_QUERY: &str = "SELECT version, name, app
 
 pub(crate) const GET_LAST_APPLIED_MIGRATION_QUERY: &str =
     "SELECT version, name, applied_on, checksum
-    FROM %MIGRATION_TABLE_NAME% WHERE version=(SELECT MAX(version) from refinery_schema_history)";
+    FROM %MIGRATION_TABLE_NAME% WHERE version=(SELECT MAX(version) from %MIGRATION_TABLE_NAME%)";
 
 pub(crate) const DEFAULT_MIGRATION_TABLE_NAME: &str = "refinery_schema_history";
 

--- a/refinery_core/src/util.rs
+++ b/refinery_core/src/util.rs
@@ -68,7 +68,7 @@ pub fn load_sql_migrations(location: impl AsRef<Path>) -> Result<Vec<Migration>,
 
     for path in migration_files {
         let sql = std::fs::read_to_string(path.as_path())
-            .map_err(|e| Error::new(Kind::InvalidMigrationPath(path.to_owned(), e), None))?;
+            .map_err(|e| Error::new(Kind::InvalidMigrationFile(path.to_owned(), e), None))?;
 
         //safe to call unwrap as find_migration_filenames returns canonical paths
         let filename = path


### PR DESCRIPTION
* Fixes a bug in `get_last_applied_migration` due to an incorrect SQL query that partially uses dynamic table names and partially hardcodes the default one.

* Adds a new utility function that enables dynamic migration discovery where embedding is not desirable.