### PR TITLE
Make the relative link to examples work from the refinery folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,7 @@ fn main() {
 }
 ```
 
-For more library examples, refer to the [`examples`](/refinery/tree/patch-1/examples).
-
+For more library examples, refer to the [`examples`](https://github.com/rust-db/refinery/tree/main/examples).
 ### Example: CLI
 
 NOTE: 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ fn main() {
 }
 ```
 
-For more library examples, refer to the [`examples`](/rust-db/refinery/tree/main/examples).
+For more library examples, refer to the [`examples`](/refinery/tree/patch-1/examples).
 
 ### Example: CLI
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ fn main() {
 }
 ```
 
-For more library examples, refer to the [`examples`](examples).
+For more library examples, refer to the [`examples`](/rust-db/refinery/tree/main/examples).
 
 ### Example: CLI
 


### PR DESCRIPTION
This `README.md` file is reused in the `refinery` folder. From there, the link to the `examples` folder don't work. I'm proposing to change the link to a relative one, starting from the `rust-db` profile.