### PR TITLE
Make `Migration::applied` public

### DIFF
--- a/refinery_core/src/runner.rs
+++ b/refinery_core/src/runner.rs
@@ -125,7 +125,7 @@ impl Migration {
     }
 
     // Create a migration from an applied migration on the database
-    pub(crate) fn applied(
+    pub fn applied(
         version: i32,
         name: String,
         applied_on: OffsetDateTime,
@@ -144,7 +144,7 @@ impl Migration {
     }
 
     // convert the Unapplied into an Applied Migration
-    pub(crate) fn set_applied(&mut self) {
+    pub fn set_applied(&mut self) {
         self.applied_on = Some(OffsetDateTime::now_utc());
         self.state = State::Applied;
     }


### PR DESCRIPTION
This is required to allow for other crates/drivers to implement refinery migration support without an unsafe transmute, as I'm doing for Snowflake currently: https://github.com/mycelial/snowflake-rs/pull/32

Ref: #248 