### PR TITLE
fix missleading CLI arguments

### DIFF
--- a/refinery_cli/src/cli.rs
+++ b/refinery_cli/src/cli.rs
@@ -44,11 +44,11 @@ pub struct MigrateArgs {
     #[clap(long, default_value = "refinery_schema_history")]
     pub table_name: String,
 
-    /// Migrate even if divergent migrations are found
+    /// Should abort if divergent migrations are found
     #[clap(short)]
     pub divergent: bool,
 
-    /// Migrate even if missing migrations are found
+    /// Should abort if missing migrations are found
     #[clap(short)]
     pub missing: bool,
 }


### PR DESCRIPTION
It looks very strange, but CLI arguments -d/-m help descriptions are inverted vs actual behaviour.

Those flags are passed as is to corresponding library methods

https://github.com/rust-db/refinery/blob/005df131468bd6e768e3b95dc3f514f9f476efe1/refinery_core/src/runner.rs#L268-L271

and

https://github.com/rust-db/refinery/blob/005df131468bd6e768e3b95dc3f514f9f476efe1/refinery_core/src/runner.rs#L278-L282

Mb by design the default behaviour expected to be fail fast, but nowadays it is not. So keeping the same behaviour, let's correct the CLI help msg =)