### PR TITLE
Support `rusqlite` 0.32.x

### DIFF
--- a/refinery_core/Cargo.toml
+++ b/refinery_core/Cargo.toml
@@ -29,7 +29,7 @@ url = "2.0"
 walkdir = "2.3.1"
 
 # allow multiple versions of the same dependency if API is similar
-rusqlite = { version = ">= 0.23, <= 0.31", optional = true }
+rusqlite = { version = ">= 0.23, <= 0.32", optional = true }
 postgres = { version = ">=0.17, <= 0.19", optional = true }
 tokio-postgres = { version = ">= 0.5, <= 0.7", optional = true }
 mysql = { version = ">= 21.0.0, <= 25", optional = true, default-features = false, features = ["minimal"] }


### PR DESCRIPTION
At the time of writing, the latest `rusqlite` version is 0.32.1.