### PR TITLE
README: add bb8 example

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,13 @@ let client = conn.deref_mut().deref_mut();
 let report = embedded::migrations::runner().run_async(client).await?;
 ```
 
+### Example: bb8
+
+```rust
+let mut client = pool.dedicated_connection().await?;
+let report = embedded::migrations::runner().run_async(&mut client).await?;
+```
+
 ### Non-contiguous VS Contiguous migrations
 
 Depending on how your project/team has been structured will define whether you want to use contiguous (adjacent) migrations `V{1}__{2}.[sql|rs]` or non-contiguous (not adjacent) migrations `U{1}__{2}.[sql|rs]`.


### PR DESCRIPTION
Otherwise 
```
AsyncMigrate` is not implemented for `PooledConnection<'_, PostgresConnectionManager<MakeRustlsConnect>>`
```

https://docs.rs/bb8/0.9.0/bb8/struct.Pool.html#method.dedicated_connection