### PR TITLE
Make a query overridable.

### DIFF
--- a/refinery_core/src/runner.rs
+++ b/refinery_core/src/runner.rs
@@ -204,7 +204,7 @@ pub struct Report {
 
 impl Report {
     /// Instantiate a new Report
-    pub(crate) fn new(applied_migrations: Vec<Migration>) -> Report {
+    pub fn new(applied_migrations: Vec<Migration>) -> Report {
         Report { applied_migrations }
     }
 

--- a/refinery_core/src/traits/async.rs
+++ b/refinery_core/src/traits/async.rs
@@ -132,15 +132,20 @@ where
         ASSERT_MIGRATIONS_TABLE_QUERY.replace("%MIGRATION_TABLE_NAME%", migration_table_name)
     }
 
+    fn get_last_applied_migration_query(migration_table_name: &str) -> String {
+        GET_LAST_APPLIED_MIGRATION_QUERY.replace("%MIGRATION_TABLE_NAME%", migration_table_name)
+    }
+
+    fn get_applied_migrations_query(migration_table_name: &str) -> String {
+        GET_APPLIED_MIGRATIONS_QUERY.replace("%MIGRATION_TABLE_NAME%", migration_table_name)
+    }
+
     async fn get_last_applied_migration(
         &mut self,
         migration_table_name: &str,
     ) -> Result<Option<Migration>, Error> {
         let mut migrations = self
-            .query(
-                &GET_LAST_APPLIED_MIGRATION_QUERY
-                    .replace("%MIGRATION_TABLE_NAME%", migration_table_name),
-            )
+            .query(Self::get_last_applied_migration_query(migration_table_name).as_str())
             .await
             .migration_err("error getting last applied migration", None)?;
 
@@ -152,10 +157,7 @@ where
         migration_table_name: &str,
     ) -> Result<Vec<Migration>, Error> {
         let migrations = self
-            .query(
-                &GET_APPLIED_MIGRATIONS_QUERY
-                    .replace("%MIGRATION_TABLE_NAME%", migration_table_name),
-            )
+            .query(Self::get_applied_migrations_query(migration_table_name).as_str())
             .await
             .migration_err("error getting applied migrations", None)?;
 
@@ -178,10 +180,7 @@ where
         .migration_err("error asserting migrations table", None)?;
 
         let applied_migrations = self
-            .query(
-                &GET_APPLIED_MIGRATIONS_QUERY
-                    .replace("%MIGRATION_TABLE_NAME%", migration_table_name),
-            )
+            .get_applied_migrations(migration_table_name)
             .await
             .migration_err("error getting current schema version", None)?;
 


### PR DESCRIPTION
- If implement to the `migrate` function, make returnable to `Report`.
- Make allow override multiple queries for a migration.

For example, it is possible to support Cassandra's CQL by implementing the following.
```

#[derive(Debug)]
struct CassandraConnection;

#[async_trait]
impl AsyncMigrate for CassandraConnection {
    fn assert_migrations_table_query(migration_table_name: &str) -> String {
        const ASSERT_MIGRATIONS_TABLE_QUERY: &'static str = r#"
            CREATE TABLE IF NOT EXISTS %MIGRATION_TABLE_NAME%(
                version INT,
                name TEXT,
                applied_on TEXT,
                checksum TEXT,
                PRIMARY KEY(version)
            )
        "#;
        ASSERT_MIGRATIONS_TABLE_QUERY.replace("%MIGRATION_TABLE_NAME%", migration_table_name)
    }

    fn get_last_applied_migration_query(migration_table_name: &str) -> String {
        const GET_LAST_APPLIED_MIGRATION_QUERY: &'static str = r#"
            SELECT version, name, applied_on, checksum
            FROM %MIGRATION_TABLE_NAME%
        "#;
        GET_LAST_APPLIED_MIGRATION_QUERY.replace("%MIGRATION_TABLE_NAME%", migration_table_name)
    }

    fn get_applied_migrations_query(migration_table_name: &str) -> String {
        const GET_APPLIED_MIGRATIONS_QUERY: &'static str = r#"
            SELECT version, name, applied_on, checksum
            FROM %MIGRATION_TABLE_NAME%;
        "#;
        GET_APPLIED_MIGRATIONS_QUERY.replace("%MIGRATION_TABLE_NAME%", migration_table_name)
    }

    async fn get_last_applied_migration(
        &mut self,
        migration_table_name: &str,
    ) -> Result<Option<Migration>, Error> {
        let mut migrations = self
            .query(Self::get_last_applied_migration_query(migration_table_name).as_str())
            .await
            .migration_err("error getting last applied migration", None)?;

        migrations.sort_by_key(|m| m.version());

        Ok(migrations.pop())
    }

    async fn get_applied_migrations(
        &mut self,
        migration_table_name: &str,
    ) -> Result<Vec<Migration>, Error> {
        let mut migrations = self
            .query(Self::get_applied_migrations_query(migration_table_name).as_str())
            .await
            .migration_err("error getting applied migrations", None)?;

        migrations.sort_by_key(|m| m.version());

        Ok(migrations)
    }
}
```