### PR TITLE
Bump maximum mysql_async version

### DIFF
--- a/refinery_core/Cargo.toml
+++ b/refinery_core/Cargo.toml
@@ -33,7 +33,7 @@ rusqlite = { version = ">= 0.23, <= 0.32", optional = true }
 postgres = { version = ">=0.17, <= 0.19", optional = true }
 tokio-postgres = { version = ">= 0.5, <= 0.7", optional = true }
 mysql = { version = ">= 21.0.0, <= 25", optional = true, default-features = false, features = ["minimal"] }
-mysql_async = { version = ">= 0.28, <= 0.34", optional = true, default-features = false, features = ["minimal"] }
+mysql_async = { version = ">= 0.28, <= 0.35", optional = true, default-features = false, features = ["minimal"] }
 tiberius = { version = ">= 0.7, <= 0.12", optional = true, default-features = false }
 tokio = { version = "1.0", optional = true }
 futures = { version = "0.3.16", optional = true, features = ["async-await"] }


### PR DESCRIPTION
A new version of mysql_async has [recently been released](https://github.com/blackbeam/mysql_async/releases/tag/v0.35.0) (0.35.0) which we need in a project that also uses refinery.

This pull request bumps the maximum mysql_async version to allow that.

We have successfully tested this on our project with the new version.