### PR TITLE
Support `rusqlite` 0.33.x

### DIFF
--- a/refinery_core/Cargo.toml
+++ b/refinery_core/Cargo.toml
@@ -29,7 +29,7 @@ url = "2.0"
 walkdir = "2.3.1"
 
 # allow multiple versions of the same dependency if API is similar
-rusqlite = { version = ">= 0.23, <= 0.32", optional = true }
+rusqlite = { version = ">= 0.23, <= 0.33", optional = true }
 postgres = { version = ">=0.17, <= 0.19", optional = true }
 tokio-postgres = { version = ">= 0.5, <= 0.7", optional = true }
 mysql = { version = ">= 21.0.0, <= 25", optional = true, default-features = false, features = ["minimal"] }


### PR DESCRIPTION
This is the latest version at time of writing.

Note to maintainer: please also do a minor version release so that co-dependents of this crate and `rusqlite` may upgrade their version of `rusqlite`. Thanks