### PR TITLE
feat: enable LTO and codegen-units = 1 optimizations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,7 @@ members = [
     "refinery_macros",
     "examples",
 ]
+
+[profile.release]
+codegen-units = 1
+lto = true


### PR DESCRIPTION
Resolves https://github.com/rust-db/refinery/discussions/351

In addition, I enabled `codegen-units = 1` - it also helps with the binary size reduction.