### PR TITLE
Prevent panic when db schema differs from migrations

### DIFF
--- a/refinery_core/src/runner.rs
+++ b/refinery_core/src/runner.rs
@@ -404,21 +404,20 @@ where
     C: Migrate,
 {
     pub(crate) fn new(runner: Runner, connection: &'a mut C) -> RunIterator<'a, C> {
+        let unapplied_migrations = Migrate::get_unapplied_migrations(
+            connection,
+            &runner.migrations,
+            runner.abort_divergent,
+            runner.abort_missing,
+            &runner.migration_table_name,
+        );
+        let failed = unapplied_migrations.is_err();
         RunIterator {
-            items: VecDeque::from(
-                Migrate::get_unapplied_migrations(
-                    connection,
-                    &runner.migrations,
-                    runner.abort_divergent,
-                    runner.abort_missing,
-                    &runner.migration_table_name,
-                )
-                .unwrap(),
-            ),
+            items: VecDeque::from(unapplied_migrations.unwrap_or_default()),
             connection,
             target: runner.target,
             migration_table_name: runner.migration_table_name.clone(),
-            failed: false,
+            failed,
         }
     }
 }


### PR DESCRIPTION
Hello,

sorry for just opening a pr without an issue linked.  
I did this because the change i have done was pretty small.  

I got this panic, when i applied a migration, then altered the database schema and ran the migration again.
![2025-03-06_13-14](https://github.com/user-attachments/assets/cc1c3b80-7b44-40c2-b39f-c84285e5bbb7)
I tracked the `unwrap()` in question down to the changed file in the pr and just updated the `failed` state of the migration.  
This allows the user to catch the error and handle it himself.

Anything i should do different?