### PR TITLE
feat: derive Serialize for Migration if serde is enabled

### DIFF
--- a/refinery_core/src/runner.rs
+++ b/refinery_core/src/runner.rs
@@ -14,6 +14,7 @@ use std::fmt::Formatter;
 
 /// An enum set that represents the type of the Migration
 #[derive(Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Type {
     Versioned,
     Unversioned,
@@ -51,6 +52,7 @@ pub enum Target {
 // an Enum set that represents the state of the migration: Applied on the database,
 // or Unapplied yet to be applied on the database
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 enum State {
     Applied,
     Unapplied,
@@ -62,6 +64,7 @@ enum State {
 ///
 /// [`embed_migrations!`]: macro.embed_migrations.html
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Migration {
     state: State,
     name: String,


### PR DESCRIPTION
To implement custom drivers it would be useful to also expose the `Migration` struct as `serde:Serializable` if the serde feature is enabled.

I currently need for a custom driver and it seems like other people implemented workarounds already (not sure if the problem is this one exactly): https://github.com/Protryon/klickhouse/blob/67651affb97dfae07084d852d99ffa652b235929/klickhouse/src/migrate.rs#L13-L66

* adds serialize/deserizalize to `Migration` and associated types if serde is enabled