### PR TITLE
Bump toml dependency from 0.8 to 1.x

### DIFF
--- a/refinery_core/Cargo.toml
+++ b/refinery_core/Cargo.toml
@@ -50,7 +50,7 @@ futures = { version = "0.3.16", optional = true, features = ["async-await"] }
 tokio-util = { version = "0.7.7", features = ["compat"], optional = true }
 time = { version = "0.3.5", features = ["parsing", "formatting"] }
 serde = { version = "1", features = ["derive"], optional = true }
-toml = { version = "0.8.8", optional = true }
+toml = { version = "1.1.2", optional = true }
 rustls = { version = "0.23", default-features = false, optional = true }
 rustls-native-certs = { version = "0.8", optional = true }
 tokio-postgres-rustls = { version = "0.13", optional = true }


### PR DESCRIPTION
Bumps the optional `toml` dependency in `refinery_core` from `0.8.8` to `1.1.2`. Most consumers presumably used toml 1.x; this makes it so that such consumers no longer need to compile both toml 0.8 and 1.X side by side.