### PR TITLE
refinery_core: replace async-trait with native async fn in trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,9 +90,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "assert_cmd"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39bae1d3fa576f7c6519514180a72559268dd7d1fe104070956cb687bc6673bd"
+checksum = "2aa3a22042e45de04255c7bf3626e239f450200fd0493c1e382263544b20aea6"
 dependencies = [
  "anstyle",
  "bstr",
@@ -241,9 +241,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -484,9 +484,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
  "const-oid 0.10.2",
@@ -828,9 +828,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
@@ -853,7 +853,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -874,9 +874,9 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.10"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
  "typenum",
 ]
@@ -982,9 +982,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -997,7 +997,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -1025,9 +1025,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
+checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
 dependencies = [
  "jiff-static",
  "log",
@@ -1038,9 +1038,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
+checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1049,10 +1049,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -1074,9 +1076,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libredox"
@@ -1158,7 +1160,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
  "cfg-if",
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1391,15 +1393,14 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl"
-version = "0.10.78"
+version = "0.10.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
+checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
 dependencies = [
  "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -1423,9 +1424,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.114"
+version = "0.9.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
+checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
 dependencies = [
  "cc",
  "libc",
@@ -1749,7 +1750,6 @@ dependencies = [
 name = "refinery-core"
 version = "0.9.0"
 dependencies = [
- "async-trait",
  "barrel 0.6.6-alpha.0",
  "cfg-if",
  "futures",
@@ -1910,9 +1910,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.38"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "once_cell",
  "ring",
@@ -1936,9 +1936,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "zeroize",
 ]
@@ -2110,7 +2110,7 @@ checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2137,9 +2137,9 @@ checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "siphasher"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -2421,9 +2421,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -2783,9 +2783,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2796,9 +2796,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2806,9 +2806,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2819,9 +2819,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
@@ -2862,9 +2862,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2872,9 +2872,9 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6a5b12f9df4f978d2cfdb1bd3bac52433f44393342d7ee9c25f5a1c14c0f45d"
+checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
 dependencies = [
  "libc",
  "libredox",
@@ -3272,9 +3272,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]

--- a/refinery_core/Cargo.toml
+++ b/refinery_core/Cargo.toml
@@ -27,7 +27,6 @@ int8-versions = []
 tokio-postgres-rustls = ["dep:tokio-postgres-rustls", "dep:rustls", "dep:rustls-native-certs", "tokio-postgres", "config"]
 
 [dependencies]
-async-trait = "0.1"
 cfg-if = "1.0"
 log = "0.4"
 regex = "1"

--- a/refinery_core/src/drivers/config.rs
+++ b/refinery_core/src/drivers/config.rs
@@ -16,7 +16,6 @@ use crate::{
     traits::{GET_APPLIED_MIGRATIONS_QUERY, GET_LAST_APPLIED_MIGRATION_QUERY},
     Error, Report, Target,
 };
-use async_trait::async_trait;
 use std::convert::Infallible;
 
 // we impl all the dependent traits as noop's and then override the methods that call them on Migrate and AsyncMigrate
@@ -37,23 +36,21 @@ impl Query<Vec<Migration>> for Config {
     }
 }
 
-#[async_trait]
 impl AsyncTransaction for Config {
     type Error = Infallible;
 
-    async fn execute<'a, T: Iterator<Item = &'a str> + Send>(
-        &mut self,
+    async fn execute<'a, T: Iterator<Item = &'a str> + Send + 'a>(
+        &'a mut self,
         _queries: T,
     ) -> Result<usize, Self::Error> {
         Ok(0)
     }
 }
 
-#[async_trait]
 impl AsyncQuery<Vec<Migration>> for Config {
-    async fn query(
-        &mut self,
-        _query: &str,
+    async fn query<'a>(
+        &'a mut self,
+        _query: &'a str,
     ) -> Result<Vec<Migration>, <Self as AsyncTransaction>::Error> {
         Ok(Vec::new())
     }
@@ -313,61 +310,66 @@ impl crate::Migrate for Config {
     feature = "tokio-postgres",
     feature = "tiberius-config"
 ))]
-#[async_trait]
 impl crate::AsyncMigrate for Config {
-    async fn get_last_applied_migration(
-        &mut self,
-        migration_table_name: &str,
-    ) -> Result<Option<Migration>, Error> {
-        with_connection_async!(self, move |mut conn| async move {
-            let mut migrations: Vec<Migration> = AsyncQuery::query(
-                &mut conn,
-                &GET_LAST_APPLIED_MIGRATION_QUERY
-                    .replace("%MIGRATION_TABLE_NAME%", migration_table_name),
-            )
-            .await
-            .migration_err("error getting last applied migration", None)?;
+    fn get_last_applied_migration<'a>(
+        &'a mut self,
+        migration_table_name: &'a str,
+    ) -> impl std::future::Future<Output = Result<Option<Migration>, Error>> + Send + 'a {
+        async move {
+            with_connection_async!(self, move |mut conn| async move {
+                let mut migrations: Vec<Migration> = conn
+                    .query(
+                        &GET_LAST_APPLIED_MIGRATION_QUERY
+                            .replace("%MIGRATION_TABLE_NAME%", migration_table_name),
+                    )
+                    .await
+                    .migration_err("error getting last applied migration", None)?;
 
-            Ok(migrations.pop())
-        })
+                Ok(migrations.pop())
+            })
+        }
     }
 
-    async fn get_applied_migrations(
-        &mut self,
-        migration_table_name: &str,
-    ) -> Result<Vec<Migration>, Error> {
-        with_connection_async!(self, move |mut conn| async move {
-            let migrations: Vec<Migration> = AsyncQuery::query(
-                &mut conn,
-                &GET_APPLIED_MIGRATIONS_QUERY
-                    .replace("%MIGRATION_TABLE_NAME%", migration_table_name),
-            )
-            .await
-            .migration_err("error getting last applied migration", None)?;
-            Ok(migrations)
-        })
+    fn get_applied_migrations<'a>(
+        &'a mut self,
+        migration_table_name: &'a str,
+    ) -> impl std::future::Future<Output = Result<Vec<Migration>, Error>> + Send + 'a {
+        async move {
+            with_connection_async!(self, move |mut conn| async move {
+                let migrations: Vec<Migration> = conn
+                    .query(
+                        &GET_APPLIED_MIGRATIONS_QUERY
+                            .replace("%MIGRATION_TABLE_NAME%", migration_table_name),
+                    )
+                    .await
+                    .migration_err("error getting last applied migration", None)?;
+                Ok(migrations)
+            })
+        }
     }
 
-    async fn migrate(
-        &mut self,
-        migrations: &[Migration],
+    fn migrate<'a>(
+        &'a mut self,
+        migrations: &'a [Migration],
         abort_divergent: bool,
         abort_missing: bool,
         grouped: bool,
         target: Target,
-        migration_table_name: &str,
-    ) -> Result<Report, Error> {
-        with_connection_async!(self, move |mut conn| async move {
-            crate::AsyncMigrate::migrate(
-                &mut conn,
-                migrations,
-                abort_divergent,
-                abort_missing,
-                grouped,
-                target,
-                migration_table_name,
-            )
-            .await
-        })
+        migration_table_name: &'a str,
+    ) -> impl std::future::Future<Output = Result<Report, Error>> + Send + 'a {
+        async move {
+            with_connection_async!(self, move |mut conn| async move {
+                crate::AsyncMigrate::migrate(
+                    &mut conn,
+                    migrations,
+                    abort_divergent,
+                    abort_missing,
+                    grouped,
+                    target,
+                    migration_table_name,
+                )
+                .await
+            })
+        }
     }
 }

--- a/refinery_core/src/drivers/mysql_async.rs
+++ b/refinery_core/src/drivers/mysql_async.rs
@@ -1,7 +1,6 @@
 use crate::traits::r#async::{AsyncMigrate, AsyncQuery, AsyncTransaction};
 use crate::util::SchemaVersion;
 use crate::Migration;
-use async_trait::async_trait;
 use mysql_async::{
     prelude::Queryable, Error as MError, IsolationLevel, Pool, Transaction as MTransaction, TxOpts,
 };
@@ -36,12 +35,11 @@ async fn query_applied_migrations<'a>(
     Ok((transaction, applied))
 }
 
-#[async_trait]
 impl AsyncTransaction for Pool {
     type Error = MError;
 
-    async fn execute<'a, T: Iterator<Item = &'a str> + Send>(
-        &mut self,
+    async fn execute<'a, T: Iterator<Item = &'a str> + Send + 'a>(
+        &'a mut self,
         queries: T,
     ) -> Result<usize, Self::Error> {
         let mut conn = self.get_conn().await?;
@@ -59,11 +57,10 @@ impl AsyncTransaction for Pool {
     }
 }
 
-#[async_trait]
 impl AsyncQuery<Vec<Migration>> for Pool {
-    async fn query(
-        &mut self,
-        query: &str,
+    async fn query<'a>(
+        &'a mut self,
+        query: &'a str,
     ) -> Result<Vec<Migration>, <Self as AsyncTransaction>::Error> {
         let mut conn = self.get_conn().await?;
         let mut options = TxOpts::new();

--- a/refinery_core/src/drivers/tiberius.rs
+++ b/refinery_core/src/drivers/tiberius.rs
@@ -2,7 +2,6 @@ use crate::traits::r#async::{AsyncMigrate, AsyncQuery, AsyncTransaction};
 use crate::util::SchemaVersion;
 use crate::Migration;
 
-use async_trait::async_trait;
 use futures::{
     io::{AsyncRead, AsyncWrite},
     TryStreamExt,
@@ -40,15 +39,14 @@ async fn query_applied_migrations<S: AsyncRead + AsyncWrite + Unpin + Send>(
     Ok(applied)
 }
 
-#[async_trait]
 impl<S> AsyncTransaction for Client<S>
 where
     S: AsyncRead + AsyncWrite + Unpin + Send,
 {
     type Error = Error;
 
-    async fn execute<'a, T: Iterator<Item = &'a str> + Send>(
-        &mut self,
+    async fn execute<'a, T: Iterator<Item = &'a str> + Send + 'a>(
+        &'a mut self,
         queries: T,
     ) -> Result<usize, Self::Error> {
         // Tiberius doesn't support transactions, see https://github.com/prisma/tiberius/issues/28
@@ -69,14 +67,13 @@ where
     }
 }
 
-#[async_trait]
 impl<S> AsyncQuery<Vec<Migration>> for Client<S>
 where
     S: AsyncRead + AsyncWrite + Unpin + Send,
 {
-    async fn query(
-        &mut self,
-        query: &str,
+    async fn query<'a>(
+        &'a mut self,
+        query: &'a str,
     ) -> Result<Vec<Migration>, <Self as AsyncTransaction>::Error> {
         let applied = query_applied_migrations(self, query).await?;
         Ok(applied)

--- a/refinery_core/src/drivers/tokio_postgres.rs
+++ b/refinery_core/src/drivers/tokio_postgres.rs
@@ -1,6 +1,5 @@
 use crate::traits::r#async::{AsyncMigrate, AsyncQuery, AsyncTransaction};
 use crate::Migration;
-use async_trait::async_trait;
 use time::format_description::well_known::Rfc3339;
 use time::OffsetDateTime;
 use tokio_postgres::error::Error as PgError;
@@ -31,12 +30,11 @@ async fn query_applied_migrations(
     Ok(applied)
 }
 
-#[async_trait]
 impl AsyncTransaction for Client {
     type Error = PgError;
 
-    async fn execute<'a, T: Iterator<Item = &'a str> + Send>(
-        &mut self,
+    async fn execute<'a, T: Iterator<Item = &'a str> + Send + 'a>(
+        &'a mut self,
         queries: T,
     ) -> Result<usize, Self::Error> {
         let transaction = self.transaction().await?;
@@ -50,11 +48,10 @@ impl AsyncTransaction for Client {
     }
 }
 
-#[async_trait]
 impl AsyncQuery<Vec<Migration>> for Client {
-    async fn query(
-        &mut self,
-        query: &str,
+    async fn query<'a>(
+        &'a mut self,
+        query: &'a str,
     ) -> Result<Vec<Migration>, <Self as AsyncTransaction>::Error> {
         let transaction = self.transaction().await?;
         let applied = query_applied_migrations(&transaction, query).await?;

--- a/refinery_core/src/traits/async.rs
+++ b/refinery_core/src/traits/async.rs
@@ -5,22 +5,23 @@ use crate::traits::{
 };
 use crate::{Error, Migration, Report, Target};
 
-use async_trait::async_trait;
+use std::future::Future;
 use std::string::ToString;
 
-#[async_trait]
-pub trait AsyncTransaction {
+pub trait AsyncTransaction: Send {
     type Error: std::error::Error + Send + Sync + 'static;
 
-    async fn execute<'a, T: Iterator<Item = &'a str> + Send>(
-        &mut self,
+    fn execute<'a, T: Iterator<Item = &'a str> + Send + 'a>(
+        &'a mut self,
         queries: T,
-    ) -> Result<usize, Self::Error>;
+    ) -> impl Future<Output = Result<usize, Self::Error>> + Send + 'a;
 }
 
-#[async_trait]
 pub trait AsyncQuery<T>: AsyncTransaction {
-    async fn query(&mut self, query: &str) -> Result<T, Self::Error>;
+    fn query<'a>(
+        &'a mut self,
+        query: &'a str,
+    ) -> impl Future<Output = Result<T, Self::Error>> + Send + 'a;
 }
 
 async fn migrate<T: AsyncTransaction>(
@@ -123,7 +124,6 @@ async fn migrate_grouped<T: AsyncTransaction>(
     Ok(Report::new(applied_migrations))
 }
 
-#[async_trait]
 pub trait AsyncMigrate: AsyncQuery<Vec<Migration>>
 where
     Self: Sized,
@@ -141,65 +141,71 @@ where
         GET_APPLIED_MIGRATIONS_QUERY.replace("%MIGRATION_TABLE_NAME%", migration_table_name)
     }
 
-    async fn get_last_applied_migration(
-        &mut self,
-        migration_table_name: &str,
-    ) -> Result<Option<Migration>, Error> {
-        let mut migrations = self
-            .query(Self::get_last_applied_migration_query(migration_table_name).as_ref())
-            .await
-            .migration_err("error getting last applied migration", None)?;
+    fn get_last_applied_migration<'a>(
+        &'a mut self,
+        migration_table_name: &'a str,
+    ) -> impl Future<Output = Result<Option<Migration>, Error>> + Send + 'a {
+        async move {
+            let mut migrations = self
+                .query(Self::get_last_applied_migration_query(migration_table_name).as_ref())
+                .await
+                .migration_err("error getting last applied migration", None)?;
 
-        Ok(migrations.pop())
+            Ok(migrations.pop())
+        }
     }
 
-    async fn get_applied_migrations(
-        &mut self,
-        migration_table_name: &str,
-    ) -> Result<Vec<Migration>, Error> {
-        let migrations = self
-            .query(Self::get_applied_migrations_query(migration_table_name).as_ref())
-            .await
-            .migration_err("error getting applied migrations", None)?;
+    fn get_applied_migrations<'a>(
+        &'a mut self,
+        migration_table_name: &'a str,
+    ) -> impl Future<Output = Result<Vec<Migration>, Error>> + Send + 'a {
+        async move {
+            let migrations = self
+                .query(Self::get_applied_migrations_query(migration_table_name).as_ref())
+                .await
+                .migration_err("error getting applied migrations", None)?;
 
-        Ok(migrations)
+            Ok(migrations)
+        }
     }
 
-    async fn migrate(
-        &mut self,
-        migrations: &[Migration],
+    fn migrate<'a>(
+        &'a mut self,
+        migrations: &'a [Migration],
         abort_divergent: bool,
         abort_missing: bool,
         grouped: bool,
         target: Target,
-        migration_table_name: &str,
-    ) -> Result<Report, Error> {
-        self.execute(
-            [Self::assert_migrations_table_query(migration_table_name).as_ref()].into_iter(),
-        )
-        .await
-        .migration_err("error asserting migrations table", None)?;
-
-        let applied_migrations = self
-            .get_applied_migrations(migration_table_name)
+        migration_table_name: &'a str,
+    ) -> impl Future<Output = Result<Report, Error>> + Send + 'a {
+        async move {
+            self.execute(
+                [Self::assert_migrations_table_query(migration_table_name).as_ref()].into_iter(),
+            )
             .await
-            .migration_err("error getting current schema version", None)?;
+            .migration_err("error asserting migrations table", None)?;
 
-        let migrations = verify_migrations(
-            applied_migrations,
-            migrations.to_vec(),
-            abort_divergent,
-            abort_missing,
-        )?;
+            let applied_migrations = self
+                .get_applied_migrations(migration_table_name)
+                .await
+                .migration_err("error getting current schema version", None)?;
 
-        if migrations.is_empty() {
-            log::info!("no migrations to apply");
-        }
+            let migrations = verify_migrations(
+                applied_migrations,
+                migrations.to_vec(),
+                abort_divergent,
+                abort_missing,
+            )?;
 
-        if grouped || matches!(target, Target::Fake | Target::FakeVersion(_)) {
-            migrate_grouped(self, migrations, target, migration_table_name).await
-        } else {
-            migrate(self, migrations, target, migration_table_name).await
+            if migrations.is_empty() {
+                log::info!("no migrations to apply");
+            }
+
+            if grouped || matches!(target, Target::Fake | Target::FakeVersion(_)) {
+                migrate_grouped(self, migrations, target, migration_table_name).await
+            } else {
+                migrate(self, migrations, target, migration_table_name).await
+            }
         }
     }
 }


### PR DESCRIPTION
Removes the `async-trait` proc-macro dependency from `refinery_core` and uses the native `async fn` in trait, which has been stable since [December 2023](https://blog.rust-lang.org/2023/12/21/async-fn-rpit-in-traits/).