### PR TITLE
Sort migrations when embedding them using `embed_migrations` macro

### DIFF
--- a/refinery_core/src/util.rs
+++ b/refinery_core/src/util.rs
@@ -78,6 +78,7 @@ pub fn find_migration_files(
 
     let re = migration_type.file_match_re();
     let file_paths = WalkDir::new(location)
+        .sort_by_key(|entry| entry.file_name().to_owned())
         .into_iter()
         .filter_map(Result::ok)
         .map(DirEntry::into_path)

--- a/refinery_core/src/util.rs
+++ b/refinery_core/src/util.rs
@@ -78,7 +78,7 @@ pub fn find_migration_files(
 
     let re = migration_type.file_match_re();
     let file_paths = WalkDir::new(location)
-        .sort_by_key(|entry| entry.file_name().to_owned())
+        .sort_by_file_name()
         .into_iter()
         .filter_map(Result::ok)
         .map(DirEntry::into_path)


### PR DESCRIPTION
By default, [`WalkDir::into_iter`](https://docs.rs/walkdir/2.5.0/walkdir/struct.WalkDir.html) returns entries in the unspecified order:

> The order is unspecified but if [sort_by](https://docs.rs/walkdir/2.5.0/walkdir/struct.WalkDir.html#method.sort_by) is given, directory entries are sorted according to this function.

This code is executed at compile time, so the result is not deterministic and that leads to non-reproducible builds (https://reproducible-builds.org/).

This patch enables sorting of directory entries, which makes the result deterministic.