### PR TITLE
chore: upgrade rusqlite support to 0.40

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -831,14 +831,17 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
+checksum = "32069d97bb81e38fa67eab65e3393bf804bb85969f2bc06bf13f64aef5aba248"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
 ]
 
 [[package]]
@@ -1089,9 +1092,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.37.0"
+version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
+checksum = "f1d20bef17f513b9b3004532233187769cd072d790971f4e4da0e346eb6401e8"
 dependencies = [
  "cc",
  "pkg-config",
@@ -1729,7 +1732,7 @@ dependencies = [
 
 [[package]]
 name = "refinery"
-version = "0.9.0"
+version = "0.9.2"
 dependencies = [
  "assert_cmd",
  "barrel 0.6.6-alpha.0",
@@ -1746,7 +1749,7 @@ dependencies = [
 
 [[package]]
 name = "refinery-core"
-version = "0.9.0"
+version = "0.9.2"
 dependencies = [
  "async-trait",
  "barrel 0.6.6-alpha.0",
@@ -1790,7 +1793,7 @@ dependencies = [
 
 [[package]]
 name = "refinery-macros"
-version = "0.9.0"
+version = "0.9.2"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1803,7 +1806,7 @@ dependencies = [
 
 [[package]]
 name = "refinery_cli"
-version = "0.9.0"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1875,9 +1878,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.39.0"
+version = "0.40.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d2b0146dd9661bf67bb107c0bb2a55064d556eeb3fc314151b957f313bcd4e"
+checksum = "23f2a97da3e3873c73cb2a2e71b35c40ff95e0b1eefa8d72d8499a6928c3b5b3"
 dependencies = [
  "bitflags",
  "fallible-iterator 0.3.0",

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -15,7 +15,7 @@ int8-versions = ["refinery/int8-versions"]
 
 [dependencies]
 refinery = { path = "../refinery", features = ["rusqlite"] }
-rusqlite = "0.39"
+rusqlite = "0.40"
 barrel = { version = "0.7", features = ["sqlite3"] }
 log = "0.4"
 env_logger = "0.11"

--- a/refinery_core/Cargo.toml
+++ b/refinery_core/Cargo.toml
@@ -37,7 +37,7 @@ url = "2.0"
 walkdir = "2.3.1"
 
 # allow multiple versions of the same dependency if API is similar
-rusqlite = { version = ">= 0.23, <= 0.39", optional = true }
+rusqlite = { version = ">= 0.23, <= 0.40", optional = true }
 postgres = { version = ">=0.17, <= 0.19", optional = true }
 native-tls = { version = "0.2", optional = true }
 postgres-native-tls = { version = "0.5", optional = true }


### PR DESCRIPTION
Upgrade support for `rustqlite` to `0.40`, covering the latest stable `0.40.2`